### PR TITLE
LabelingType: Allow access to index of type directly.

### DIFF
--- a/src/main/java/net/imglib2/labeling/LabelingType.java
+++ b/src/main/java/net/imglib2/labeling/LabelingType.java
@@ -231,5 +231,17 @@ public class LabelingType< T extends Comparable< T >> implements Type< LabelingT
 	{
 		return mapping;
 	}
+	
+	/**
+	 * @return {@link IntegerType} holding the current index at the position of the LabelingType. 
+	 * 
+	 * NB: The returned {@link IntegerType} should be used read-only. Don't write to this type. 
+	 * The value of the {@link IntegerType} refers to a key in the {@link LabelingMapping}. 
+	 * Writing to this type may invalidate the caching of the {@link LabelingROIStrategy}.
+	 */
+	public IntegerType< ? > getIndex()
+	{
+		return type;
+	}
 
 }


### PR DESCRIPTION
For efficient rendering we need to have access to the index of the labeling (i.e. the value of the underlying NativeImg). 
