### PR TITLE
LabelingMapping: Make InternedList protected

### DIFF
--- a/src/main/java/net/imglib2/labeling/LabelingMapping.java
+++ b/src/main/java/net/imglib2/labeling/LabelingMapping.java
@@ -78,7 +78,7 @@ public class LabelingMapping< T extends Comparable< T >>
 		theEmptyList = intern( background );
 	}
 
-	private static class InternedList< T1 extends Comparable< T1 >> implements List< T1 >
+	protected static class InternedList< T1 extends Comparable< T1 >> implements List< T1 >
 	{
 		private final List< T1 > value;
 


### PR DESCRIPTION
for fast serialization/deserialization of the LabelingMapping we must be able to create InternedLists from outside.

@tpietzsch I know there is some refactoring going on, but maybe we can add this beforehands such that we get a back to a stable build of our software? Would be great!