### PR TITLE
Let IterableRegion implements IterableInterval < VoidType >

### DIFF
--- a/src/main/java/net/imglib2/roi/IterableRegion.java
+++ b/src/main/java/net/imglib2/roi/IterableRegion.java
@@ -53,5 +53,5 @@ import net.imglib2.type.BooleanType;
  *
  * @author Tobias Pietzsch <tobias.pietzsch@gmail.com>
  */
-public interface IterableRegion< T extends BooleanType< T > > extends IterableInterval< T >, RandomAccessibleInterval< T >
+public interface IterableRegion< T extends BooleanType< T > > extends IterableInterval< Void >, RandomAccessibleInterval< T >
 {}

--- a/src/main/java/net/imglib2/roi/Regions.java
+++ b/src/main/java/net/imglib2/roi/Regions.java
@@ -51,7 +51,6 @@ public class Regions
 		return SamplingIterableInterval.create( region, img );
 	}
 
-	@SuppressWarnings( "unchecked" )
 	public static < B extends BooleanType< B > > IterableRegion< B > iterable( final RandomAccessibleInterval< B > region )
 	{
 		if ( region instanceof IterableRegion )

--- a/src/main/java/net/imglib2/roi/labeling/LabelRegion.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelRegion.java
@@ -203,9 +203,9 @@ public class LabelRegion< T > extends AbstractLocalizable implements Positionabl
 	}
 
 	@Override
-	public BoolType firstElement()
+	public Void firstElement()
 	{
-		return cursor().next();
+		return null;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/roi/labeling/LabelRegionCursor.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelRegionCursor.java
@@ -41,12 +41,9 @@ import net.imglib2.AbstractLocalizable;
 import net.imglib2.Cursor;
 import net.imglib2.Point;
 import net.imglib2.roi.util.iterationcode.IterationCodeListIterator;
-import net.imglib2.type.logic.BoolType;
 
-public class LabelRegionCursor extends AbstractLocalizable implements Cursor< BoolType >
+public class LabelRegionCursor extends AbstractLocalizable implements Cursor< Void >
 {
-	private final BoolType type = new BoolType( true );
-
 	private final IterationCodeListIterator< Point > iter;
 
 	public LabelRegionCursor( final ArrayList< TIntArrayList > itcodesList, final long[] offset )
@@ -62,9 +59,9 @@ public class LabelRegionCursor extends AbstractLocalizable implements Cursor< Bo
 	}
 
 	@Override
-	public BoolType get()
+	public Void get()
 	{
-		return type;
+		return null;
 	}
 
 	@Override
@@ -92,10 +89,10 @@ public class LabelRegionCursor extends AbstractLocalizable implements Cursor< Bo
 	}
 
 	@Override
-	public BoolType next()
+	public Void next()
 	{
 		fwd();
-		return get();
+		return null;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/roi/util/IterableRandomAccessibleRegion.java
+++ b/src/main/java/net/imglib2/roi/util/IterableRandomAccessibleRegion.java
@@ -77,7 +77,7 @@ public class IterableRandomAccessibleRegion< T extends BooleanType< T > >
 	}
 
 	@Override
-	public T firstElement()
+	public Void firstElement()
 	{
 		return cursor().next();
 	}
@@ -89,19 +89,19 @@ public class IterableRandomAccessibleRegion< T extends BooleanType< T > >
 	}
 
 	@Override
-	public Iterator< T > iterator()
+	public Iterator< Void > iterator()
 	{
 		return cursor();
 	}
 
 	@Override
-	public Cursor< T > cursor()
+	public Cursor< Void> cursor()
 	{
 		return new RandomAccessibleRegionCursor< T >( sourceInterval, size );
 	}
 
 	@Override
-	public Cursor< T > localizingCursor()
+	public Cursor< Void > localizingCursor()
 	{
 		return cursor();
 	}

--- a/src/main/java/net/imglib2/roi/util/RandomAccessibleRegionCursor.java
+++ b/src/main/java/net/imglib2/roi/util/RandomAccessibleRegionCursor.java
@@ -39,7 +39,7 @@ import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.BooleanType;
 
-public class RandomAccessibleRegionCursor< T extends BooleanType< T > > extends AbstractWrappedInterval< RandomAccessibleInterval< T > > implements Cursor< T >
+public class RandomAccessibleRegionCursor<T extends BooleanType< T >> extends AbstractWrappedInterval< RandomAccessibleInterval< T > > implements Cursor< Void >
 {
 	private final RandomAccess< T > randomAccess;
 
@@ -74,9 +74,9 @@ public class RandomAccessibleRegionCursor< T extends BooleanType< T > > extends 
 	}
 
 	@Override
-	public T get()
+	public Void get()
 	{
-		return randomAccess.get();
+		return null;
 	}
 
 	@Override
@@ -129,7 +129,7 @@ public class RandomAccessibleRegionCursor< T extends BooleanType< T > > extends 
 	}
 
 	@Override
-	public T next()
+	public Void next()
 	{
 		fwd();
 		return get();


### PR DESCRIPTION
Currently, the Cursor created from an `IterableRegion< T >` returns `<T extends BooleanType<T>>` which always had the value `true`, as only pixels belonging to the `IterableRegion` are iterated. Instead of returning a `BooleanType` which is always true, we now return `Void`.