### PR TITLE
Improve WritablePolygon2D and WritablePolyline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,9 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
+
+		<imglib2.version>5.5.0</imglib2.version>
+		<trove4j.version>3.0.3</trove4j.version>
 	</properties>
 
 	<developers>

--- a/src/main/java/net/imglib2/roi/geom/GeomMasks.java
+++ b/src/main/java/net/imglib2/roi/geom/GeomMasks.java
@@ -40,7 +40,9 @@ import java.util.List;
 import net.imglib2.KDTree;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPointSampleList;
+import net.imglib2.roi.BoundaryType;
 import net.imglib2.roi.MaskPredicate;
+import net.imglib2.roi.geom.real.Box;
 import net.imglib2.roi.geom.real.ClosedWritableBox;
 import net.imglib2.roi.geom.real.ClosedWritableEllipsoid;
 import net.imglib2.roi.geom.real.ClosedWritablePolygon2D;
@@ -86,13 +88,19 @@ public class GeomMasks
 
 	// -- Box --
 
-	/** Creates a {@link ClosedWritableBox}. */
+	/**
+	 * Creates a {@link WritableBox} with {@link BoundaryType#CLOSED closed}
+	 * {@link MaskPredicate#boundaryType() boundaries}.
+	 */
 	public static WritableBox closedBox( final double[] min, final double[] max )
 	{
 		return new ClosedWritableBox( min, max );
 	}
 
-	/** Creates an {@link OpenWritableBox}. */
+	/**
+	 * Creates a {@link WritableBox} with {@link BoundaryType#OPEN open}
+	 * {@link MaskPredicate#boundaryType() boundaries}.
+	 */
 	public static WritableBox openBox( final double[] min, final double[] max )
 	{
 		return new OpenWritableBox( min, max );
@@ -100,13 +108,19 @@ public class GeomMasks
 
 	// -- Ellipsoid --
 
-	/** Creates a {@link ClosedWritableEllipsoid}. */
+	/**
+	 * Creates a {@link WritableEllipsoid} with {@link BoundaryType#CLOSED
+	 * closed} {@link MaskPredicate#boundaryType() boundaries}.
+	 */
 	public static WritableEllipsoid closedEllipsoid( final double[] center, final double[] semiAxisLengths )
 	{
 		return new ClosedWritableEllipsoid( center, semiAxisLengths );
 	}
 
-	/** Creates an {@link OpenWritableEllipsoid}. */
+	/**
+	 * Creates a {@link WritableEllipsoid} with {@link BoundaryType#OPEN
+	 * open} {@link MaskPredicate#boundaryType() boundaries}.
+	 */
 	public static WritableEllipsoid openEllipsoid( final double[] center, final double[] semiAxisLengths )
 	{
 		return new OpenWritableEllipsoid( center, semiAxisLengths );
@@ -114,13 +128,13 @@ public class GeomMasks
 
 	// -- Line --
 
-	/** Creates a {@link DefaultWritableLine}. */
+	/** Creates a {@link WritableLine} from two {@link RealLocalizable} points. */
 	public static WritableLine line( final RealLocalizable pointOne, final RealLocalizable pointTwo )
 	{
 		return new DefaultWritableLine( pointOne, pointTwo );
 	}
 
-	/** Creates a {@link DefaultWritableLine}. */
+	/** Creates a {@link WritableLine} from two {@code double[]} points. */
 	public static WritableLine line( final double[] pointOne, final double[] pointTwo, final boolean copy )
 	{
 		return new DefaultWritableLine( pointOne, pointTwo, copy );
@@ -128,13 +142,17 @@ public class GeomMasks
 
 	// -- Point --
 
-	/** Creates a {@link DefaultWritablePointMask}. */
+	/**
+	 * Creates a {@link WritablePointMask} from {@code double[]} coordinates.
+	 */
 	public static WritablePointMask pointMask( final double[] point )
 	{
 		return new DefaultWritablePointMask( point );
 	}
 
-	/** Creates a {@link DefaultWritablePointMask}. */
+	/**
+	 * Creates a {@link WritablePointMask} from a {@link RealLocalizable} point.
+	 */
 	public static WritablePointMask pointMask( final RealLocalizable point )
 	{
 		return new DefaultWritablePointMask( point );
@@ -142,37 +160,61 @@ public class GeomMasks
 
 	// -- Polygon2D --
 
-	/** Creates a {@link DefaultWritablePolygon2D}. */
+	/**
+	 * Creates a {@link WritablePolygon2D} from a list of vertices, with
+	 * {@link BoundaryType#UNSPECIFIED unspecified}
+	 * {@link MaskPredicate#boundaryType() boundaries}.
+	 */
 	public static WritablePolygon2D polygon2D( final List< ? extends RealLocalizable > vertices )
 	{
 		return new DefaultWritablePolygon2D( vertices );
 	}
 
-	/** Creates a {@link DefaultWritablePolygon2D}. */
+	/**
+	 * Creates a {@link WritablePolygon2D} from a list of (x, y) coordinates,
+	 * with {@link BoundaryType#UNSPECIFIED unspecified}
+	 * {@link MaskPredicate#boundaryType() boundaries}.
+	 */
 	public static WritablePolygon2D polygon2D( final double[] x, final double[] y )
 	{
 		return new DefaultWritablePolygon2D( x, y );
 	}
 
-	/** Creates a {@link ClosedWritablePolygon2D}. */
+	/**
+	 * Creates a {@link WritablePolygon2D} from a list of vertices, with
+	 * {@link BoundaryType#CLOSED closed} {@link MaskPredicate#boundaryType()
+	 * boundaries}.
+	 */
 	public static WritablePolygon2D closedPolygon2D( final List< ? extends RealLocalizable > vertices )
 	{
 		return new ClosedWritablePolygon2D( vertices );
 	}
 
-	/** Creates a {@link ClosedWritablePolygon2D}. */
+	/**
+	 * Creates a {@link WritablePolygon2D} from a list of (x, y) coordinates,
+	 * with {@link BoundaryType#CLOSED closed}
+	 * {@link MaskPredicate#boundaryType() boundaries}.
+	 */
 	public static WritablePolygon2D closedPolygon2D( final double[] x, final double[] y )
 	{
 		return new ClosedWritablePolygon2D( x, y );
 	}
 
-	/** Creates an {@link OpenWritablePolygon2D}. */
+	/**
+	 * Creates a {@link WritablePolygon2D} from a list of vertices, with
+	 * {@link BoundaryType#OPEN open} {@link MaskPredicate#boundaryType()
+	 * boundaries}.
+	 */
 	public static WritablePolygon2D openPolygon2D( final List< ? extends RealLocalizable > vertices )
 	{
 		return new OpenWritablePolygon2D( vertices );
 	}
 
-	/** Creates an {@link OpenWritablePolygon2D}. */
+	/**
+	 * Creates a {@link WritablePolygon2D} from a list of (x, y) coordinates,
+	 * with {@link BoundaryType#OPEN open} {@link MaskPredicate#boundaryType()
+	 * boundaries}.
+	 */
 	public static WritablePolygon2D openPolygon2D( final double[] x, final double[] y )
 	{
 		return new OpenWritablePolygon2D( x, y );
@@ -180,7 +222,7 @@ public class GeomMasks
 
 	// -- Polyline --
 
-	/** Creates a {@link DefaultWritablePolyline}. */
+	/** Creates a {@link WritablePolyline} from a list of vertices. */
 	public static WritablePolyline polyline( final List< ? extends RealLocalizable > vertices )
 	{
 		return new DefaultWritablePolyline( vertices );
@@ -188,51 +230,66 @@ public class GeomMasks
 
 	// -- RealPointCollection --
 
-	/** Creates a {@link DefaultWritableRealPointCollection}. */
+	/** Creates a {@link WritableRealPointCollection} from a map of points. */
 	public static < L extends RealLocalizable > WritableRealPointCollection< L > realPointCollection( final HashMap< TDoubleArrayList, L > points )
 	{
 		return new DefaultWritableRealPointCollection<>( points );
 	}
 
-	/** Creates a {@link DefaultWritableRealPointCollection}. */
+	/** Creates a {@link WritableRealPointCollection} from a collection of points. */
 	public static < L extends RealLocalizable > WritableRealPointCollection< L > realPointCollection( final Collection< L > points )
 	{
 		return new DefaultWritableRealPointCollection<>( points );
 	}
 
-	/** Creates a {@link KDTreeRealPointCollection}. */
+	/** Creates a {@link RealPointCollection} from a {@link KDTree}. */
 	public static < L extends RealLocalizable > RealPointCollection< L > kDTreeRealPointCollection( final KDTree< L > tree )
 	{
 		return new KDTreeRealPointCollection<>( tree );
 	}
 
-	/** Creates a {@link KDTreeRealPointCollection}. */
-	public static < L extends RealLocalizable > RealPointCollection< L > kDTreeRealPointCollection( final Collection< L > points )
+	/**
+	 * Creates a {@link KDTree}-based {@link RealPointCollection} from a
+	 * collection of points.
+	 */
+	public static < L extends RealLocalizable > KDTreeRealPointCollection< L > kDTreeRealPointCollection( final Collection< L > points )
 	{
 		return new KDTreeRealPointCollection<>( points );
 	}
 
-	/** Creates a {@link RealPointSampleListWritableRealPointCollection}. */
+	/**
+	 * Creates a {@link WritableRealPointCollection} from a
+	 * {@Link RealPointSampleList}.
+	 */
 	public static < L extends RealLocalizable > WritableRealPointCollection< L > realPointSampleListRealPointCollection( final RealPointSampleList< L > points )
 	{
 		return new RealPointSampleListWritableRealPointCollection<>( points );
 	}
 
-	/** Creates a {@link RealPointSampleListWritableRealPointCollection}. */
-	public static < L extends RealLocalizable > WritableRealPointCollection< L > realPointSampleListRealPointCollection( final Collection< L > points )
+	/**
+	 * Creates a {@link RealPointSampleList}-based
+	 * {@link WritableRealPointCollection} from a collection of points.
+	 */
+	public static < L extends RealLocalizable > RealPointSampleListWritableRealPointCollection< L > realPointSampleListRealPointCollection( final Collection< L > points )
 	{
 		return new RealPointSampleListWritableRealPointCollection<>( points );
 	}
 
 	// -- Sphere --
 
-	/** Creates a {@link ClosedWritableSphere}. */
+	/**
+	 * Creates a {@link WritableSphere} with {@link BoundaryType#CLOSED closed}
+	 * {@link MaskPredicate#boundaryType() boundaries}.
+	 */
 	public static WritableSphere closedSphere( final double[] center, final double radius )
 	{
 		return new ClosedWritableSphere( center, radius );
 	}
 
-	/** Creates an {@link OpenWritableSphere}. */
+	/**
+	 * Creates a {@link WritableSphere} with {@link BoundaryType#OPEN open}
+	 * {@link MaskPredicate#boundaryType() boundaries}.
+	 */
 	public static WritableSphere openSphere( final double[] center, final double radius )
 	{
 		return new OpenWritableSphere( center, radius );
@@ -240,7 +297,10 @@ public class GeomMasks
 
 	// -- SuperEllipsoid --
 
-	/** Creates a {@link ClosedWritableSuperEllipsoid}. */
+	/**
+	 * Creates a {@link WritableSuperEllipsoid} with {@link BoundaryType#CLOSED
+	 * closed} {@link MaskPredicate#boundaryType() boundaries}.
+	 */
 	public static WritableSuperEllipsoid closedSuperEllipsoid( final double[] center, final double[] semiAxisLengths, final double exponent )
 	{
 		if ( exponent == 2 )
@@ -248,7 +308,10 @@ public class GeomMasks
 		return new ClosedWritableSuperEllipsoid( center, semiAxisLengths, exponent );
 	}
 
-	/** Creates an {@link OpenWritableSuperEllipsoid}. */
+	/**
+	 * Creates a {@link WritableSuperEllipsoid} with {@link BoundaryType#OPEN
+	 * open} {@link MaskPredicate#boundaryType() boundaries}.
+	 */
 	public static WritableSuperEllipsoid openSuperEllipsoid( final double[] center, final double[] semiAxisLengths, final double exponent )
 	{
 		if ( exponent == 2 )

--- a/src/main/java/net/imglib2/roi/geom/real/DefaultWritablePolygon2D.java
+++ b/src/main/java/net/imglib2/roi/geom/real/DefaultWritablePolygon2D.java
@@ -141,10 +141,10 @@ public class DefaultWritablePolygon2D extends AbstractRealInterval implements Wr
 	 * will be ignored.
 	 */
 	@Override
-	public void addVertex( final int index, final double[] vertex )
+	public void addVertex( final int index, final RealLocalizable vertex )
 	{
-		x.insert( index, vertex[ 0 ] );
-		y.insert( index, vertex[ 1 ] );
+		x.insert( index, vertex.getDoublePosition( 0 ) );
+		y.insert( index, vertex.getDoublePosition( 1 ) );
 		updateMinMax();
 	}
 

--- a/src/main/java/net/imglib2/roi/geom/real/DefaultWritablePolygon2D.java
+++ b/src/main/java/net/imglib2/roi/geom/real/DefaultWritablePolygon2D.java
@@ -143,9 +143,11 @@ public class DefaultWritablePolygon2D extends AbstractRealInterval implements Wr
 	@Override
 	public void addVertex( final int index, final RealLocalizable vertex )
 	{
-		x.insert( index, vertex.getDoublePosition( 0 ) );
-		y.insert( index, vertex.getDoublePosition( 1 ) );
-		updateMinMax();
+		final double px = vertex.getDoublePosition( 0 );
+		final double py = vertex.getDoublePosition( 1 );
+		x.insert( index, px );
+		y.insert( index, py );
+		expandMinMax(px, py, px, py);
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/roi/geom/real/DefaultWritablePolygon2D.java
+++ b/src/main/java/net/imglib2/roi/geom/real/DefaultWritablePolygon2D.java
@@ -233,26 +233,26 @@ public class DefaultWritablePolygon2D extends AbstractRealInterval implements Wr
 
 	private void updateMinMax()
 	{
-		double maxX = x.get( 0 );
-		double minX = x.get( 0 );
-		double maxY = y.get( 0 );
-		double minY = y.get( 0 );
-		for ( int i = 1; i < numVertices(); i++ )
+		min[ 0 ] = min[ 1 ] = Double.POSITIVE_INFINITY;
+		max[ 0 ] = max[ 1 ] = Double.NEGATIVE_INFINITY;
+		for ( int i = 0; i < numVertices(); i++ )
 		{
-			if ( x.get( i ) > maxX )
-				maxX = x.get( i );
-			if ( x.get( i ) < minX )
-				minX = x.get( i );
-			if ( y.get( i ) > maxY )
-				maxY = y.get( i );
-			if ( y.get( i ) < minY )
-				minY = y.get( i );
+			final double px = x.get( i );
+			final double py = y.get( i );
+			expandMinMax( px, py, px, py );
 		}
+	}
 
-		max[ 0 ] = maxX;
-		max[ 1 ] = maxY;
-		min[ 0 ] = minX;
-		min[ 1 ] = minY;
+	private void expandMinMax( final double xMin, final double yMin, final double xMax, final double yMax )
+	{
+		if ( xMax > max[ 0 ] )
+			max[ 0 ] = xMax;
+		if ( yMax > max[ 1 ] )
+			max[ 1 ] = yMax;
+		if ( xMin < min[ 0 ] )
+			min[ 0 ] = xMin;
+		if ( yMin < min[ 1 ] )
+			min[ 1 ] = yMin;
 	}
 
 	// -- Helper classes --

--- a/src/main/java/net/imglib2/roi/geom/real/DefaultWritablePolyline.java
+++ b/src/main/java/net/imglib2/roi/geom/real/DefaultWritablePolyline.java
@@ -35,6 +35,7 @@
 package net.imglib2.roi.geom.real;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import net.imglib2.AbstractRealInterval;
@@ -168,19 +169,21 @@ public class DefaultWritablePolyline extends AbstractRealInterval implements Wri
 
 	private void updateMinMax()
 	{
-		for ( int d = 0; d < n; d++ )
+		Arrays.fill( min, Double.POSITIVE_INFINITY );
+		Arrays.fill( max, Double.NEGATIVE_INFINITY );
+		for ( double[] vertex : vertices ) {
+			expandMinMax( vertex, vertex );
+		}
+	}
+
+	private void expandMinMax( final double[] mn, final double[] mx )
+	{
+		for ( int d = 0; d < numDimensions(); d++ )
 		{
-			double minD = vertices.get( 0 )[ d ];
-			double maxD = vertices.get( 0 )[ d ];
-			for ( int i = 1; i < numVertices(); i++ )
-			{
-				if ( vertices.get( i )[ d ] < minD )
-					minD = vertices.get( i )[ d ];
-				if ( vertices.get( i )[ d ] > maxD )
-					maxD = vertices.get( i )[ d ];
-			}
-			min[ d ] = minD;
-			max[ d ] = maxD;
+			if ( mx[ d ] > max[ d ] )
+				max[ d ] = mx[ d ];
+			if ( mn[ d ] < min[ d ] )
+				min[ d ] = mn[ d ];
 		}
 	}
 

--- a/src/main/java/net/imglib2/roi/geom/real/DefaultWritablePolyline.java
+++ b/src/main/java/net/imglib2/roi/geom/real/DefaultWritablePolyline.java
@@ -118,7 +118,7 @@ public class DefaultWritablePolyline extends AbstractRealInterval implements Wri
 		for ( int d = 0; d < n; d++ )
 			p[ d ] = vertex.getDoublePosition( d );
 		vertices.add( index, p );
-		updateMinMax();
+		expandMinMax( p, p );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/roi/geom/real/DefaultWritableRealPointCollection.java
+++ b/src/main/java/net/imglib2/roi/geom/real/DefaultWritableRealPointCollection.java
@@ -116,7 +116,14 @@ public class DefaultWritableRealPointCollection< L extends RealLocalizable > ext
 		point.localize( l );
 		points.put( new TDoubleArrayList( l ), point );
 
-		updateMinMax();
+		// Update bounds.
+		for ( int d = 0; d < numDimensions(); d++ )
+		{
+			if ( l[ d ] > max[ d ] )
+				max[ d ] = l[ d ];
+			if ( l[ d ] < min[ d ] )
+				min[ d ] = l[ d ];
+		}
 	}
 
 	/**

--- a/src/main/java/net/imglib2/roi/geom/real/Polygon2D.java
+++ b/src/main/java/net/imglib2/roi/geom/real/Polygon2D.java
@@ -49,4 +49,10 @@ public interface Polygon2D extends RealMaskRealInterval
 
 	/** Get the number of vertices */
 	int numVertices();
+
+	@Override
+	default int numDimensions()
+	{
+		return 2;
+	}
 }

--- a/src/main/java/net/imglib2/roi/geom/real/Polyline.java
+++ b/src/main/java/net/imglib2/roi/geom/real/Polyline.java
@@ -34,7 +34,6 @@
 
 package net.imglib2.roi.geom.real;
 
-import net.imglib2.RealLocalizable;
 import net.imglib2.roi.BoundaryType;
 import net.imglib2.roi.RealMaskRealInterval;
 
@@ -43,14 +42,8 @@ import net.imglib2.roi.RealMaskRealInterval;
  *
  * @author Alison Walter
  */
-public interface Polyline extends RealMaskRealInterval
+public interface Polyline extends Polyshape
 {
-	/** Returns the vertex at the specified position. */
-	RealLocalizable vertex( final int pos );
-
-	/** Returns the number of vertices which define this polyline. */
-	int numVertices();
-
 	@Override
 	default BoundaryType boundaryType()
 	{

--- a/src/main/java/net/imglib2/roi/geom/real/Polyshape.java
+++ b/src/main/java/net/imglib2/roi/geom/real/Polyshape.java
@@ -34,18 +34,20 @@
 
 package net.imglib2.roi.geom.real;
 
+import net.imglib2.RealLocalizable;
 import net.imglib2.roi.RealMaskRealInterval;
 
 /**
- * A {@link RealMaskRealInterval} which defines a real space 2D polygon.
+ * A {@link RealMaskRealInterval} which defines a polygonal shape in n-d space.
  *
  * @author Alison Walter
+ * @author Curtis Rueden
  */
-public interface Polygon2D extends Polyshape
+public interface Polyshape extends RealMaskRealInterval
 {
-	@Override
-	default int numDimensions()
-	{
-		return 2;
-	}
+	/** Returns the vertex at the specified position. */
+	RealLocalizable vertex( final int pos );
+
+	/** Returns the number of vertices in the shape. */
+	int numVertices();
 }

--- a/src/main/java/net/imglib2/roi/geom/real/WritablePolyline.java
+++ b/src/main/java/net/imglib2/roi/geom/real/WritablePolyline.java
@@ -34,22 +34,12 @@
 
 package net.imglib2.roi.geom.real;
 
-import net.imglib2.RealLocalizable;
-import net.imglib2.roi.util.RealLocalizableRealPositionable;
-
 /**
  * A modifiable {@link Polyline}.
  *
  * @author Alison Walter
  */
-public interface WritablePolyline extends Polyline
+public interface WritablePolyline extends Polyline, WritablePolyshape
 {
-	@Override
-	RealLocalizableRealPositionable vertex( final int pos );
-
-	/** Adds a vertex at the given index. */
-	void addVertex( int index, RealLocalizable vertex );
-
-	/** Removes the vertex at the given index. */
-	void removeVertex( int index );
+	// NB: Marker interface.
 }

--- a/src/main/java/net/imglib2/roi/geom/real/WritablePolyshape.java
+++ b/src/main/java/net/imglib2/roi/geom/real/WritablePolyshape.java
@@ -35,20 +35,22 @@
 package net.imglib2.roi.geom.real;
 
 import net.imglib2.RealLocalizable;
-import net.imglib2.RealPoint;
+import net.imglib2.roi.util.RealLocalizableRealPositionable;
 
 /**
- * A modifiable {@link Polygon2D}.
+ * A modifiable {@link Polyshape}.
  *
  * @author Alison Walter
  * @author Curtis Rueden
  */
-public interface WritablePolygon2D extends Polygon2D, WritablePolyshape
+public interface WritablePolyshape extends Polyshape
 {
-	/** @deprecated Use {@link #addVertex(int, RealLocalizable)} instead. */
-	@Deprecated
-	default void addVertex( int index, double[] vertex )
-	{
-		addVertex( index, RealPoint.wrap( vertex ) );
-	}
+	@Override
+	RealLocalizableRealPositionable vertex( final int pos );
+
+	/** Adds a vertex at the given index. */
+	void addVertex( int index, RealLocalizable vertex );
+
+	/** Removes the vertex at the given index. */
+	void removeVertex( int index );
 }

--- a/src/main/java/net/imglib2/roi/geom/real/WritablePolyshape.java
+++ b/src/main/java/net/imglib2/roi/geom/real/WritablePolyshape.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.roi.geom.real;
 
+import java.util.Collection;
+
 import net.imglib2.RealLocalizable;
 import net.imglib2.roi.util.RealLocalizableRealPositionable;
 
@@ -53,4 +55,7 @@ public interface WritablePolyshape extends Polyshape
 
 	/** Removes the vertex at the given index. */
 	void removeVertex( int index );
+
+	/** Adds vertices starting at the given index. */
+	void addVertices( int index, Collection< RealLocalizable > vertices );
 }

--- a/src/test/java/net/imglib2/roi/geom/WritablePolygon2DTest.java
+++ b/src/test/java/net/imglib2/roi/geom/WritablePolygon2DTest.java
@@ -216,7 +216,7 @@ public class WritablePolygon2DTest
 
 		assertFalse( p.test( new RealPoint( 20, 6.5 ) ) );
 
-		p.addVertex( 4, new double[] { 20, 5 } );
+		p.addVertex( 4, new RealPoint( 20, 5 ) );
 		assertEquals( 6, p.numVertices() );
 		assertEquals( p.vertex( 4 ).getDoublePosition( 0 ), 20, 0 );
 		assertEquals( p.vertex( 4 ).getDoublePosition( 1 ), 5, 0 );
@@ -326,7 +326,7 @@ public class WritablePolygon2DTest
 	{
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( points );
 
-		p.addVertex( 3, new double[] { 1, 2, 3 } );
+		p.addVertex( 3, new RealPoint( 1, 2, 3 ) );
 		assertEquals( 1, p.vertex( 3 ).getDoublePosition( 0 ), 0 );
 		assertEquals( 2, p.vertex( 3 ).getDoublePosition( 1 ), 0 );
 	}
@@ -346,7 +346,7 @@ public class WritablePolygon2DTest
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( points );
 
 		exception.expect( IndexOutOfBoundsException.class );
-		p.addVertex( 3, new double[] {} );
+		p.addVertex( 3, new RealPoint() );
 	}
 
 	@Test
@@ -364,7 +364,7 @@ public class WritablePolygon2DTest
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( points );
 
 		exception.expect( IndexOutOfBoundsException.class );
-		p.addVertex( 6, new double[] { 1, 2 } );
+		p.addVertex( 6, new RealPoint( 1, 2 ) );
 	}
 
 	@Test
@@ -405,7 +405,7 @@ public class WritablePolygon2DTest
 		assertArrayEquals( min, pMin, 0 );
 		assertArrayEquals( max, pMax, 0 );
 
-		p.addVertex( 1, new double[] { -10, 100 } );
+		p.addVertex( 1, new RealPoint( -10, 100 ) );
 		min[ 0 ] = -10;
 		max[ 1 ] = 100;
 		p.realMin( pMin );

--- a/src/test/java/net/imglib2/roi/geom/WritablePolygon2DTest.java
+++ b/src/test/java/net/imglib2/roi/geom/WritablePolygon2DTest.java
@@ -120,7 +120,7 @@ public class WritablePolygon2DTest
 		assertFalse( polygon.test( outside ) );
 
 		// 2D polygon characteristics
-		assertEquals( polygon.numVertices(), 5 );
+		assertEquals( 5, polygon.numVertices() );
 		assertTrue( assertRealLocalizableEquals( polygon.vertex( 0 ), points.get( 0 ) ) );
 		assertTrue( assertRealLocalizableEquals( polygon.vertex( 2 ), points.get( 2 ) ) );
 		assertTrue( assertRealLocalizableEquals( polygon.vertex( 4 ), points.get( 4 ) ) );
@@ -154,7 +154,7 @@ public class WritablePolygon2DTest
 		assertFalse( polygon.test( outside ) );
 
 		// 2D polygon characteristics
-		assertEquals( polygon.numVertices(), 5 );
+		assertEquals( 5, polygon.numVertices() );
 		assertTrue( assertRealLocalizableEquals( polygon.vertex( 1 ), points.get( 1 ) ) );
 		assertTrue( assertRealLocalizableEquals( polygon.vertex( 3 ), points.get( 3 ) ) );
 		assertTrue( assertRealLocalizableEquals( polygon.vertex( 4 ), points.get( 4 ) ) );
@@ -188,7 +188,7 @@ public class WritablePolygon2DTest
 		assertFalse( polygon.test( outside ) );
 
 		// 2D polygon characteristics
-		assertEquals( polygon.numVertices(), 5 );
+		assertEquals( 5, polygon.numVertices() );
 		assertTrue( assertRealLocalizableEquals( polygon.vertex( 0 ), points.get( 0 ) ) );
 		assertTrue( assertRealLocalizableEquals( polygon.vertex( 1 ), points.get( 1 ) ) );
 		assertTrue( assertRealLocalizableEquals( polygon.vertex( 2 ), points.get( 2 ) ) );
@@ -203,9 +203,9 @@ public class WritablePolygon2DTest
 		assertFalse( p.test( new RealPoint( 30, 11 ) ) );
 
 		p.vertex( 3 ).setPosition( new double[] { 40, 10 } );
-		assertEquals( p.numVertices(), 5, 0 );
-		assertEquals( p.vertex( 3 ).getDoublePosition( 0 ), 40, 0 );
-		assertEquals( p.vertex( 3 ).getDoublePosition( 1 ), 10, 1 );
+		assertEquals( 5, p.numVertices() );
+		assertEquals( 40, p.vertex( 3 ).getDoublePosition( 0 ), 0 );
+		assertEquals( 10, p.vertex( 3 ).getDoublePosition( 1 ), 0 );
 		assertTrue( p.test( new RealPoint( 30, 11 ) ) );
 	}
 
@@ -217,7 +217,7 @@ public class WritablePolygon2DTest
 		assertFalse( p.test( new RealPoint( 20, 6.5 ) ) );
 
 		p.addVertex( 4, new double[] { 20, 5 } );
-		assertEquals( p.numVertices(), 6, 0 );
+		assertEquals( 6, p.numVertices() );
 		assertEquals( p.vertex( 4 ).getDoublePosition( 0 ), 20, 0 );
 		assertEquals( p.vertex( 4 ).getDoublePosition( 1 ), 5, 0 );
 		assertTrue( p.test( new RealPoint( 20, 6.5 ) ) );
@@ -231,9 +231,9 @@ public class WritablePolygon2DTest
 		assertTrue( p.test( new RealPoint( 20.125, 17 ) ) );
 
 		p.removeVertex( 1 );
-		assertEquals( p.numVertices(), 4, 0 );
-		assertEquals( p.vertex( 1 ).getDoublePosition( 0 ), 25, 0 );
-		assertEquals( p.vertex( 1 ).getDoublePosition( 1 ), 15, 0 );
+		assertEquals( 4, p.numVertices(),  0 );
+		assertEquals( 25, p.vertex( 1 ).getDoublePosition( 0 ), 0 );
+		assertEquals( 15, p.vertex( 1 ).getDoublePosition( 1 ), 0 );
 		assertFalse( p.test( new RealPoint( 20.125, 17 ) ) );
 	}
 
@@ -246,8 +246,8 @@ public class WritablePolygon2DTest
 		pts.add( new RealPoint( 10, 10 ) );
 
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( pts );
-		assertEquals( p.vertex( 0 ).getDoublePosition( 0 ), 0, 0 );
-		assertEquals( p.vertex( 0 ).getDoublePosition( 1 ), 0, 0 );
+		assertEquals( 0, p.vertex( 0 ).getDoublePosition( 0 ), 0 );
+		assertEquals( 0, p.vertex( 0 ).getDoublePosition( 1 ), 0 );
 	}
 
 	@Test
@@ -260,9 +260,9 @@ public class WritablePolygon2DTest
 
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( pts );
 
-		assertEquals( p.numVertices(), 3 );
-		assertEquals( p.vertex( 1 ).getDoublePosition( 0 ), 5, 0 );
-		assertEquals( p.vertex( 1 ).getDoublePosition( 1 ), 5, 0 );
+		assertEquals( 3, p.numVertices() );
+		assertEquals( 5, p.vertex( 1 ).getDoublePosition( 0 ), 0 );
+		assertEquals( 5, p.vertex( 1 ).getDoublePosition( 1 ), 0 );
 	}
 
 	@Test
@@ -285,9 +285,9 @@ public class WritablePolygon2DTest
 
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( x, y );
 
-		assertEquals( p.numVertices(), 7 );
-		assertEquals( p.vertex( 6 ).getDoublePosition( 0 ), 7, 0 );
-		assertEquals( p.vertex( 6 ).getDoublePosition( 1 ), 7, 0 );
+		assertEquals( 7, p.numVertices() );
+		assertEquals( 7, p.vertex( 6 ).getDoublePosition( 0 ), 0 );
+		assertEquals( 7, p.vertex( 6 ).getDoublePosition( 1 ), 0 );
 
 		exception.expect( IndexOutOfBoundsException.class );
 		p.vertex( 7 );
@@ -302,13 +302,13 @@ public class WritablePolygon2DTest
 		vertices.add( new RealPoint( 10, 9, 8 ) );
 
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( vertices );
-		assertEquals( p.numVertices(), 3 );
-		assertEquals( p.vertex( 0 ).getDoublePosition( 0 ), 1, 0 );
-		assertEquals( p.vertex( 0 ).getDoublePosition( 1 ), 2, 0 );
-		assertEquals( p.vertex( 1 ).getDoublePosition( 0 ), -1, 0 );
-		assertEquals( p.vertex( 1 ).getDoublePosition( 1 ), -2, 0 );
-		assertEquals( p.vertex( 2 ).getDoublePosition( 0 ), 10, 0 );
-		assertEquals( p.vertex( 2 ).getDoublePosition( 1 ), 9, 0 );
+		assertEquals( 3, p.numVertices() );
+		assertEquals( 1, p.vertex( 0 ).getDoublePosition( 0 ), 0 );
+		assertEquals( 2, p.vertex( 0 ).getDoublePosition( 1 ), 0 );
+		assertEquals( -1, p.vertex( 1 ).getDoublePosition( 0 ), 0 );
+		assertEquals( -2, p.vertex( 1 ).getDoublePosition( 1 ), 0 );
+		assertEquals( 10, p.vertex( 2 ).getDoublePosition( 0 ), 0 );
+		assertEquals( 9, p.vertex( 2 ).getDoublePosition( 1 ), 0 );
 	}
 
 	@Test
@@ -317,8 +317,8 @@ public class WritablePolygon2DTest
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( points );
 
 		p.vertex( 0 ).setPosition( new double[] { 1, 2, 3 } );
-		assertEquals( p.vertex( 0 ).getDoublePosition( 0 ), 1, 0 );
-		assertEquals( p.vertex( 0 ).getDoublePosition( 1 ), 2, 0 );
+		assertEquals( 1, p.vertex( 0 ).getDoublePosition( 0 ), 0 );
+		assertEquals( 2, p.vertex( 0 ).getDoublePosition( 1 ), 0 );
 	}
 
 	@Test
@@ -327,8 +327,8 @@ public class WritablePolygon2DTest
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( points );
 
 		p.addVertex( 3, new double[] { 1, 2, 3 } );
-		assertEquals( p.vertex( 3 ).getDoublePosition( 0 ), 1, 0 );
-		assertEquals( p.vertex( 3 ).getDoublePosition( 1 ), 2, 0 );
+		assertEquals( 1, p.vertex( 3 ).getDoublePosition( 0 ), 0 );
+		assertEquals( 2, p.vertex( 3 ).getDoublePosition( 1 ), 0 );
 	}
 
 	@Test

--- a/src/test/java/net/imglib2/roi/geom/WritablePolygon2DTest.java
+++ b/src/test/java/net/imglib2/roi/geom/WritablePolygon2DTest.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPoint;
@@ -50,6 +51,7 @@ import net.imglib2.roi.geom.real.DefaultWritablePolygon2D;
 import net.imglib2.roi.geom.real.OpenWritablePolygon2D;
 import net.imglib2.roi.geom.real.Polygon2D;
 import net.imglib2.roi.geom.real.WritablePolygon2D;
+import net.imglib2.util.Util;
 
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -235,6 +237,32 @@ public class WritablePolygon2DTest
 		assertEquals( 25, p.vertex( 1 ).getDoublePosition( 0 ), 0 );
 		assertEquals( 15, p.vertex( 1 ).getDoublePosition( 1 ), 0 );
 		assertFalse( p.test( new RealPoint( 20.125, 17 ) ) );
+	}
+
+	@Test
+	public void testAddVertices()
+	{
+		final WritablePolygon2D p = new ClosedWritablePolygon2D( points );
+
+		// Generate a bunch of random points.
+		final Random r = new Random(0xdeadbeef);
+		final int extraCount = 99;
+		final List < RealLocalizable > extra = new ArrayList<>();
+		for ( int i = 0; i < extraCount; i++ )
+			extra.add( new RealPoint( r.nextDouble(), r.nextDouble() ) );
+
+		// Add the random points.
+		final int offset = 3;
+		p.addVertices( offset, extra );
+
+		// Check that they match.
+		assertEquals( 5 + extraCount, p.numVertices() );
+		int index = offset;
+		for ( final RealLocalizable expected : extra )
+		{
+			final RealLocalizable actual = p.vertex( index );
+			assertTrue( "Index #" + index++, Util.locationsEqual( expected, actual ) );
+		}
 	}
 
 	@Test

--- a/src/test/java/net/imglib2/roi/geom/WritablePolygon2DTest.java
+++ b/src/test/java/net/imglib2/roi/geom/WritablePolygon2DTest.java
@@ -70,9 +70,9 @@ public class WritablePolygon2DTest
 
 	private static List< RealLocalizable > edge = new ArrayList<>();
 
-	private static RealPoint inside = new RealPoint( new double[] { 20, 14 } );
+	private static RealPoint inside = new RealPoint( 20, 14 );
 
-	private static RealPoint outside = new RealPoint( new double[] { 26, 30 } );
+	private static RealPoint outside = new RealPoint( 26, 30 );
 
 	@BeforeClass
 	public static void initTest()
@@ -200,13 +200,13 @@ public class WritablePolygon2DTest
 	{
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( points );
 
-		assertFalse( p.test( new RealPoint( new double[] { 30, 11 } ) ) );
+		assertFalse( p.test( new RealPoint( 30, 11 ) ) );
 
 		p.vertex( 3 ).setPosition( new double[] { 40, 10 } );
 		assertEquals( p.numVertices(), 5, 0 );
 		assertEquals( p.vertex( 3 ).getDoublePosition( 0 ), 40, 0 );
 		assertEquals( p.vertex( 3 ).getDoublePosition( 1 ), 10, 1 );
-		assertTrue( p.test( new RealPoint( new double[] { 30, 11 } ) ) );
+		assertTrue( p.test( new RealPoint( 30, 11 ) ) );
 	}
 
 	@Test
@@ -214,13 +214,13 @@ public class WritablePolygon2DTest
 	{
 		final WritablePolygon2D p = new ClosedWritablePolygon2D( points );
 
-		assertFalse( p.test( new RealPoint( new double[] { 20, 6.5 } ) ) );
+		assertFalse( p.test( new RealPoint( 20, 6.5 ) ) );
 
 		p.addVertex( 4, new double[] { 20, 5 } );
 		assertEquals( p.numVertices(), 6, 0 );
 		assertEquals( p.vertex( 4 ).getDoublePosition( 0 ), 20, 0 );
 		assertEquals( p.vertex( 4 ).getDoublePosition( 1 ), 5, 0 );
-		assertTrue( p.test( new RealPoint( new double[] { 20, 6.5 } ) ) );
+		assertTrue( p.test( new RealPoint( 20, 6.5 ) ) );
 	}
 
 	@Test
@@ -228,22 +228,22 @@ public class WritablePolygon2DTest
 	{
 		final WritablePolygon2D p = new OpenWritablePolygon2D( points );
 
-		assertTrue( p.test( new RealPoint( new double[] { 20.125, 17 } ) ) );
+		assertTrue( p.test( new RealPoint( 20.125, 17 ) ) );
 
 		p.removeVertex( 1 );
 		assertEquals( p.numVertices(), 4, 0 );
 		assertEquals( p.vertex( 1 ).getDoublePosition( 0 ), 25, 0 );
 		assertEquals( p.vertex( 1 ).getDoublePosition( 1 ), 15, 0 );
-		assertFalse( p.test( new RealPoint( new double[] { 20.125, 17 } ) ) );
+		assertFalse( p.test( new RealPoint( 20.125, 17 ) ) );
 	}
 
 	@Test
 	public void testFirstRealLocalizableHigherDim()
 	{
 		final List< RealLocalizable > pts = new ArrayList<>();
-		pts.add( new RealPoint( new double[] { 0, 0, 0 } ) );
-		pts.add( new RealPoint( new double[] { 5, 5 } ) );
-		pts.add( new RealPoint( new double[] { 10, 10 } ) );
+		pts.add( new RealPoint( 0, 0, 0 ) );
+		pts.add( new RealPoint( 5, 5 ) );
+		pts.add( new RealPoint( 10, 10 ) );
 
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( pts );
 		assertEquals( p.vertex( 0 ).getDoublePosition( 0 ), 0, 0 );
@@ -254,9 +254,9 @@ public class WritablePolygon2DTest
 	public void testLaterRealLocalizableHigherDim()
 	{
 		final List< RealLocalizable > pts = new ArrayList<>();
-		pts.add( new RealPoint( new double[] { 0, 0 } ) );
-		pts.add( new RealPoint( new double[] { 5, 5, 5 } ) );
-		pts.add( new RealPoint( new double[] { 10, 10 } ) );
+		pts.add( new RealPoint( 0, 0 ) );
+		pts.add( new RealPoint( 5, 5, 5 ) );
+		pts.add( new RealPoint( 10, 10 ) );
 
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( pts );
 
@@ -269,9 +269,9 @@ public class WritablePolygon2DTest
 	public void testRealLocalizableSmallerDim()
 	{
 		final List< RealLocalizable > pts = new ArrayList<>();
-		pts.add( new RealPoint( new double[] { 0, 0 } ) );
-		pts.add( new RealPoint( new double[] { 5, 5, 5 } ) );
-		pts.add( new RealPoint( new double[] { 10 } ) );
+		pts.add( new RealPoint( 0, 0 ) );
+		pts.add( new RealPoint( 5, 5, 5 ) );
+		pts.add( new RealPoint( 10.0 ) );
 
 		exception.expect( IndexOutOfBoundsException.class );
 		new DefaultWritablePolygon2D( pts );
@@ -297,9 +297,9 @@ public class WritablePolygon2DTest
 	public void testDimGreaterThanTwo()
 	{
 		final List< RealPoint > vertices = new ArrayList<>();
-		vertices.add( new RealPoint( new double[] { 1, 2, 3 } ) );
-		vertices.add( new RealPoint( new double[] { -1, -2, -3 } ) );
-		vertices.add( new RealPoint( new double[] { 10, 9, 8 } ) );
+		vertices.add( new RealPoint( 1, 2, 3 ) );
+		vertices.add( new RealPoint( -1, -2, -3 ) );
+		vertices.add( new RealPoint( 10, 9, 8 ) );
 
 		final WritablePolygon2D p = new DefaultWritablePolygon2D( vertices );
 		assertEquals( p.numVertices(), 3 );

--- a/src/test/java/net/imglib2/roi/geom/WritablePolylineTest.java
+++ b/src/test/java/net/imglib2/roi/geom/WritablePolylineTest.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPoint;
@@ -50,6 +51,7 @@ import net.imglib2.roi.geom.real.DefaultWritablePolyline;
 import net.imglib2.roi.geom.real.Line;
 import net.imglib2.roi.geom.real.Polyline;
 import net.imglib2.roi.geom.real.WritablePolyline;
+import net.imglib2.util.Util;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -237,6 +239,32 @@ public class WritablePolylineTest
 		assertEquals( pl.numVertices(), 2 );
 		assertTrue( assertRealLocalizableEquals( pl.vertex( 1 ), beforeRemove ) );
 		assertTrue( pl.test( new RealPoint( new double[] { 13, 3.125 } ) ) );
+	}
+
+	@Test
+	public void testAddVertices()
+	{
+		final WritablePolyline pl = new DefaultWritablePolyline( polyline );
+
+		// Generate a bunch of random points.
+		final Random r = new Random(0xdeadbeef);
+		final int extraCount = 99;
+		final List < RealLocalizable > extra = new ArrayList<>();
+		for ( int i = 0; i < extraCount; i++ )
+			extra.add( new RealPoint( r.nextDouble(), r.nextDouble() ) );
+
+		// Add the random points.
+		final int offset = 1;
+		pl.addVertices( offset, extra );
+
+		// Check that they match.
+		assertEquals( 3 + extraCount, pl.numVertices() );
+		int index = offset;
+		for ( final RealLocalizable expected : extra )
+		{
+			final RealLocalizable actual = pl.vertex( index );
+			assertTrue( "Index #" + index++, Util.locationsEqual( expected, actual ) );
+		}
 	}
 
 	@Test


### PR DESCRIPTION
This branch makes the following improvements:

* `Polygon2D` and `Polyline` common API is now inherited from `Polyshape` interface.
* `WritablePolygon2D` and `WritablePolyline` common API is now inherited from `WritablePolyshape` interface. The `WritablePolygon2D#addVertex(int, double[])` method is deprecated in favor of `WritablePolyshape#addVertex(int, RealLocalizable)`.
* `DefaultWritablePolygon2D#addVertex`, `DefaultWritablePolyline#addVertex` and `DefaultWritableRealPointCollection#addPoint` now update the bounds based on the new point only, avoiding an O(n) bounds rebuild. (`RealPointSampleListWritableRealPointCollection` did not suffer from this issue.)
* `WritablePolyshape` gained an `addVertices` method for adding many vertices at once. This bulk operation enables the default implementations to perform better, expanding their internal storage once as appropriate, rather than doing repeated incremental expansions.
* Add methods to `GeomMaths` to compare `Localizable` and `RealLocalizable` positions. (Maybe these should go into `net.imglib2.util.Util`? What do others think?)
* The `WritablePolygon2DTest` code has been improved a bit.

Note that `WritableRealPointCollection` still does not have `addPoints` or `removePoints` methods; I considered doing them as part of this PR, but I have no immediate use case, so I've held off for now.

With these changes, it will be more feasible to pass `WritablePolyshape` objects as outputs into which calculated points can be injected. In particular, it will become feasible to recast ImageJ Ops's geometry operations such as `geom.convexHull(Polygon2D)` as computer ops rather than function ops.