### PR TITLE
Fix ImgLabeling for various types of index images

### DIFF
--- a/src/main/java/net/imglib2/roi/labeling/ImgLabeling.java
+++ b/src/main/java/net/imglib2/roi/labeling/ImgLabeling.java
@@ -157,12 +157,13 @@ public class ImgLabeling< T, I extends IntegerType< I > >
 		public LabelingConvertedRandomAccess( final RandomAccess< I > source )
 		{
 			super( source );
-			this.type = new LabelingType<>( source.get(), mapping, generation );
+			this.type = new LabelingType<>( null, mapping, generation );
 		}
 
 		@Override
 		public LabelingType< T > get()
 		{
+			type.setType( source.get() );
 			return type;
 		}
 
@@ -180,12 +181,13 @@ public class ImgLabeling< T, I extends IntegerType< I > >
 		public LabelingConvertedCursor( final Cursor< I > source )
 		{
 			super( source );
-			this.type = new LabelingType<>( source.get(), mapping, generation );
+			this.type = new LabelingType<>( null, mapping, generation );
 		}
 
 		@Override
 		public LabelingType< T > get()
 		{
+			type.setType( source.get() );
 			return type;
 		}
 

--- a/src/main/java/net/imglib2/roi/labeling/LabelingType.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelingType.java
@@ -64,7 +64,7 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 
 	protected final LabelingMapping< T > mapping;
 
-	protected final IntegerType< ? > type;
+	protected IntegerType< ? > type;
 
 	/**
 	 * Constructor for mirroring state with another labeling
@@ -81,6 +81,10 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 		this.type = type;
 		this.mapping = mapping;
 		this.generation = modCount;
+	}
+
+	void setType( final IntegerType< ? > type) {
+		this.type = type;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/roi/labeling/LabelingType.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelingType.java
@@ -86,7 +86,8 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 		this.generation = modCount;
 	}
 
-	void setType( final IntegerType< ? > type) {
+	void setType( final IntegerType< ? > type )
+	{
 		this.type = type;
 	}
 

--- a/src/test/java/net/imglib2/roi/labeling/ImgLabelingBenchmark.java
+++ b/src/test/java/net/imglib2/roi/labeling/ImgLabelingBenchmark.java
@@ -1,0 +1,57 @@
+package net.imglib2.roi.labeling;
+
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.IntType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import static junit.framework.TestCase.assertFalse;
+
+@State( value = Scope.Benchmark )
+public class ImgLabelingBenchmark
+{
+	Img<IntType > indexImg = ArrayImgs.ints(100, 100, 100);
+	ImgLabeling<String, ?> imgLabeling = new ImgLabeling<>( indexImg );
+
+	@Benchmark
+	public void benchmarkCursor( Blackhole bh ) {
+		Cursor< LabelingType< String > > cursor = imgLabeling.cursor();
+		while( cursor.hasNext() )
+			bh.consume( cursor.next() );
+	}
+
+	@Benchmark
+	public void benchmarkRandomAccess( Blackhole bh ) {
+		RandomAccess< LabelingType< String > > randomAccess = imgLabeling.randomAccess();
+		Cursor< ? > cursor = indexImg.localizingCursor();
+		while( cursor.hasNext() )
+		{
+			cursor.fwd();
+			randomAccess.setPosition( cursor );
+			bh.consume( randomAccess.get() );
+		}
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( ImgLabelingBenchmark.class.getSimpleName() )
+				.forks( 0 )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 100 ) )
+				.measurementTime( TimeValue.milliseconds( 100 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+}

--- a/src/test/java/net/imglib2/roi/labeling/ImgLabelingBenchmark.java
+++ b/src/test/java/net/imglib2/roi/labeling/ImgLabelingBenchmark.java
@@ -5,6 +5,7 @@ import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.integer.IntType;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -15,26 +16,27 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
-import static junit.framework.TestCase.assertFalse;
-
 @State( value = Scope.Benchmark )
 public class ImgLabelingBenchmark
 {
-	Img<IntType > indexImg = ArrayImgs.ints(100, 100, 100);
-	ImgLabeling<String, ?> imgLabeling = new ImgLabeling<>( indexImg );
+	Img< IntType > indexImg = ArrayImgs.ints( 100, 100, 100 );
+
+	ImgLabeling< String, ? > imgLabeling = new ImgLabeling<>( indexImg );
 
 	@Benchmark
-	public void benchmarkCursor( Blackhole bh ) {
-		Cursor< LabelingType< String > > cursor = imgLabeling.cursor();
-		while( cursor.hasNext() )
+	public void benchmarkCursor( final Blackhole bh )
+	{
+		final Cursor< LabelingType< String > > cursor = imgLabeling.cursor();
+		while ( cursor.hasNext() )
 			bh.consume( cursor.next() );
 	}
 
 	@Benchmark
-	public void benchmarkRandomAccess( Blackhole bh ) {
-		RandomAccess< LabelingType< String > > randomAccess = imgLabeling.randomAccess();
-		Cursor< ? > cursor = indexImg.localizingCursor();
-		while( cursor.hasNext() )
+	public void benchmarkRandomAccess( final Blackhole bh )
+	{
+		final RandomAccess< LabelingType< String > > randomAccess = imgLabeling.randomAccess();
+		final Cursor< ? > cursor = indexImg.localizingCursor();
+		while ( cursor.hasNext() )
 		{
 			cursor.fwd();
 			randomAccess.setPosition( cursor );
@@ -42,7 +44,7 @@ public class ImgLabelingBenchmark
 		}
 	}
 
-	public static void main( String... args ) throws RunnerException
+	public static void main( final String... args ) throws RunnerException
 	{
 		final Options opt = new OptionsBuilder()
 				.include( ImgLabelingBenchmark.class.getSimpleName() )

--- a/src/test/java/net/imglib2/roi/labeling/ImgLabelingTest.java
+++ b/src/test/java/net/imglib2/roi/labeling/ImgLabelingTest.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -33,17 +33,8 @@
  */
 package net.imglib2.roi.labeling;
 
-import net.imglib2.Cursor;
-import net.imglib2.RandomAccess;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.img.Img;
-import net.imglib2.img.array.ArrayImgs;
-import net.imglib2.img.list.ListImgFactory;
-import net.imglib2.type.numeric.integer.IntType;
-import net.imglib2.type.numeric.integer.UnsignedIntType;
-
-import net.imglib2.view.Views;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,74 +43,89 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.list.ListImgFactory;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.view.Views;
+
+import org.junit.Test;
 
 /**
  * @author Matthias Arzt
  */
-public class ImgLabelingTest {
+public class ImgLabelingTest
+{
 
 	@Test
-	public void testCreateFromImageAndLabelSets() {
-		// setup
-		Img<UnsignedIntType> image = ArrayImgs.unsignedInts(new int[]{1, 0, 2}, 3);
-		String[] values = {"A", "B"};
-		String[] valuesB = {"Hello", "World"};
-		List<Set<String>> labelSets = Arrays.asList(asSet(), asSet(values), asSet(valuesB));
-		// process
-		ImgLabeling<String, UnsignedIntType> labeling = ImgLabeling.fromImageAndLabelSets(image, labelSets);
-		// test
-		RandomAccess<LabelingType<String>> ra = labeling.randomAccess();
-		ra.setPosition(new long[]{0});
-		assertEquals(asSet(values), ra.get());
-		ra.setPosition(new long[]{1});
-		assertEquals(Collections.emptySet(), ra.get());
-		ra.setPosition(new long[]{2});
-		assertEquals(asSet(valuesB), ra.get());
-	}
-
-	@Test
-	public void testCreateFromImageAndLabels() {
-		// setup
-		Img<UnsignedIntType> image = ArrayImgs.unsignedInts(new int[]{3}, 1);
-		List<String> labels = Arrays.asList("a", "b", "c", "d", "e", "f", "g");
-		// process
-		ImgLabeling<String, UnsignedIntType> labeling = ImgLabeling.fromImageAndLabels(image, labels);
-		// test
-		RandomAccess<LabelingType<String>> ra = labeling.randomAccess();
-		ra.setPosition(new long[]{0});
-		assertEquals(asSet("c"), ra.get());
-	}
-
-	@Test
-	public void testModifyCreatedImgLabeling() {
-		// setup
-		int[] data = {2};
-		Img<UnsignedIntType> image = ArrayImgs.unsignedInts(data, 1);
-		List<Set<String>> labelSets = Arrays.asList(asSet(), asSet("1","2"), asSet("1"));
-		ImgLabeling<String, UnsignedIntType> labeling = ImgLabeling.fromImageAndLabelSets(image, labelSets);
-		RandomAccess<LabelingType<String>> ra = labeling.randomAccess();
-		ra.setPosition(new long[]{0});
-		// process
-		ra.get().add("2");
-		// test
-		assertEquals(asSet("1", "2"), ra.get());
-		assertEquals(1, data[0]);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testCreatedImgLabelingRepeatingLabel() {
-		Img<UnsignedIntType> image = ArrayImgs.unsignedInts(new int[]{2}, 1);
-		ImgLabeling<String, UnsignedIntType> labeling = ImgLabeling.fromImageAndLabels(image, Arrays.asList("1", "1"));
-	}
-
-	@Test public void testBackedByListImgRandomAccess()
+	public void testCreateFromImageAndLabelSets()
 	{
-		Img< IntType > image =
+		// setup
+		final Img< UnsignedIntType > image = ArrayImgs.unsignedInts( new int[] { 1, 0, 2 }, 3 );
+		final String[] values = { "A", "B" };
+		final String[] valuesB = { "Hello", "World" };
+		final List< Set< String > > labelSets = Arrays.asList( asSet(), asSet( values ), asSet( valuesB ) );
+		// process
+		final ImgLabeling< String, UnsignedIntType > labeling = ImgLabeling.fromImageAndLabelSets( image, labelSets );
+		// test
+		final RandomAccess< LabelingType< String > > ra = labeling.randomAccess();
+		ra.setPosition( new long[] { 0 } );
+		assertEquals( asSet( values ), ra.get() );
+		ra.setPosition( new long[] { 1 } );
+		assertEquals( Collections.emptySet(), ra.get() );
+		ra.setPosition( new long[] { 2 } );
+		assertEquals( asSet( valuesB ), ra.get() );
+	}
+
+	@Test
+	public void testCreateFromImageAndLabels()
+	{
+		// setup
+		final Img< UnsignedIntType > image = ArrayImgs.unsignedInts( new int[] { 3 }, 1 );
+		final List< String > labels = Arrays.asList( "a", "b", "c", "d", "e", "f", "g" );
+		// process
+		final ImgLabeling< String, UnsignedIntType > labeling = ImgLabeling.fromImageAndLabels( image, labels );
+		// test
+		final RandomAccess< LabelingType< String > > ra = labeling.randomAccess();
+		ra.setPosition( new long[] { 0 } );
+		assertEquals( asSet( "c" ), ra.get() );
+	}
+
+	@Test
+	public void testModifyCreatedImgLabeling()
+	{
+		// setup
+		final int[] data = { 2 };
+		final Img< UnsignedIntType > image = ArrayImgs.unsignedInts( data, 1 );
+		final List< Set< String > > labelSets = Arrays.asList( asSet(), asSet( "1", "2" ), asSet( "1" ) );
+		final ImgLabeling< String, UnsignedIntType > labeling = ImgLabeling.fromImageAndLabelSets( image, labelSets );
+		final RandomAccess< LabelingType< String > > ra = labeling.randomAccess();
+		ra.setPosition( new long[] { 0 } );
+		// process
+		ra.get().add( "2" );
+		// test
+		assertEquals( asSet( "1", "2" ), ra.get() );
+		assertEquals( 1, data[ 0 ] );
+	}
+
+	@Test( expected = IllegalArgumentException.class )
+	public void testCreatedImgLabelingRepeatingLabel()
+	{
+		final Img< UnsignedIntType > image = ArrayImgs.unsignedInts( new int[] { 2 }, 1 );
+		final ImgLabeling< String, UnsignedIntType > labeling = ImgLabeling.fromImageAndLabels( image, Arrays.asList( "1", "1" ) );
+	}
+
+	@Test
+	public void testBackedByListImgRandomAccess()
+	{
+		final Img< IntType > image =
 				new ListImgFactory<>( new IntType() ).create( new long[] { 2 } );
-		ImgLabeling< String, IntType > labeling = new ImgLabeling<>( image );
-		RandomAccess< LabelingType< String > > ra = labeling.randomAccess();
+		final ImgLabeling< String, IntType > labeling = new ImgLabeling<>( image );
+		final RandomAccess< LabelingType< String > > ra = labeling.randomAccess();
 		ra.setPosition( 0, 0 );
 		ra.get().add( "a" );
 		ra.setPosition( 1, 0 );
@@ -127,41 +133,44 @@ public class ImgLabelingTest {
 		assertEquals( Collections.singleton( "b" ), ra.get() );
 	}
 
-	@Test public void testBackedByListImgCursor()
+	@Test
+	public void testBackedByListImgCursor()
 	{
-		Img< IntType > image =
+		final Img< IntType > image =
 				new ListImgFactory<>( new IntType() ).create( new long[] { 2 } );
-		ImgLabeling< String, IntType > labeling = new ImgLabeling<>( image );
-		Cursor< LabelingType< String > > cursor = labeling.cursor();
+		final ImgLabeling< String, IntType > labeling = new ImgLabeling<>( image );
+		final Cursor< LabelingType< String > > cursor = labeling.cursor();
 		cursor.next().add( "a" );
 		cursor.next().add( "b" );
 		assertEquals( Collections.singleton( "b" ), cursor.get() );
 	}
 
-	@Test public void testBackedByStack()
+	@Test
+	public void testBackedByStack()
 	{
-		RandomAccessibleInterval< IntType > a = ArrayImgs.ints( 1 );
-		RandomAccessibleInterval< IntType > b = ArrayImgs.ints( 1 );
-		RandomAccessibleInterval< IntType > image = Views.stack( a, b );
-		ImgLabeling< String, IntType > labeling = new ImgLabeling<>( image );
-		Cursor< LabelingType< String > > cursor = labeling.cursor();
+		final RandomAccessibleInterval< IntType > a = ArrayImgs.ints( 1 );
+		final RandomAccessibleInterval< IntType > b = ArrayImgs.ints( 1 );
+		final RandomAccessibleInterval< IntType > image = Views.stack( a, b );
+		final ImgLabeling< String, IntType > labeling = new ImgLabeling<>( image );
+		final Cursor< LabelingType< String > > cursor = labeling.cursor();
 		cursor.next().add( "a" );
 		cursor.next().add( "b" );
 		assertEquals( Collections.singleton( "b" ), cursor.get() );
 	}
 
-	private <T> Set<T> asSet(T... values) {
-		return new TreeSet<>(Arrays.asList(values));
+	private < T > Set< T > asSet( final T... values )
+	{
+		return new TreeSet<>( Arrays.asList( values ) );
 	}
 
 	@Test
 	public void testHashCodeAndEquals()
 	{
-		ImgLabeling< String, IntType > labeling = new ImgLabeling<>( ArrayImgs.ints( 1, 1 ) );
-		LabelingType< String > pixel = labeling.firstElement();
+		final ImgLabeling< String, IntType > labeling = new ImgLabeling<>( ArrayImgs.ints( 1, 1 ) );
+		final LabelingType< String > pixel = labeling.firstElement();
 		pixel.add( "foo" );
 		pixel.add( "bar" );
-		HashSet< String > expected = new HashSet<>( Arrays.asList( "foo", "bar" ) );
+		final HashSet< String > expected = new HashSet<>( Arrays.asList( "foo", "bar" ) );
 		assertTrue( pixel.equals( expected ) );
 		assertEquals( expected.hashCode(), pixel.hashCode() );
 	}

--- a/src/test/java/net/imglib2/roi/labeling/ImgLabelingTest.java
+++ b/src/test/java/net/imglib2/roi/labeling/ImgLabelingTest.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -33,11 +33,16 @@
  */
 package net.imglib2.roi.labeling;
 
+import net.imglib2.Cursor;
 import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.list.ListImgFactory;
+import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.UnsignedIntType;
 
+import net.imglib2.view.Views;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -105,6 +110,42 @@ public class ImgLabelingTest {
 	public void testCreatedImgLabelingRepeatingLabel() {
 		Img<UnsignedIntType> image = ArrayImgs.unsignedInts(new int[]{2}, 1);
 		ImgLabeling<String, UnsignedIntType> labeling = ImgLabeling.fromImageAndLabels(image, Arrays.asList("1", "1"));
+	}
+
+	@Test public void testBackedByListImgRandomAccess()
+	{
+		Img< IntType > image =
+				new ListImgFactory<>( new IntType() ).create( new long[] { 2 } );
+		ImgLabeling< String, IntType > labeling = new ImgLabeling<>( image );
+		RandomAccess< LabelingType< String > > ra = labeling.randomAccess();
+		ra.setPosition( 0, 0 );
+		ra.get().add( "a" );
+		ra.setPosition( 1, 0 );
+		ra.get().add( "b" );
+		assertEquals( Collections.singleton( "b" ), ra.get() );
+	}
+
+	@Test public void testBackedByListImgCursor()
+	{
+		Img< IntType > image =
+				new ListImgFactory<>( new IntType() ).create( new long[] { 2 } );
+		ImgLabeling< String, IntType > labeling = new ImgLabeling<>( image );
+		Cursor< LabelingType< String > > cursor = labeling.cursor();
+		cursor.next().add( "a" );
+		cursor.next().add( "b" );
+		assertEquals( Collections.singleton( "b" ), cursor.get() );
+	}
+
+	@Test public void testBackedByStack()
+	{
+		RandomAccessibleInterval< IntType > a = ArrayImgs.ints( 1 );
+		RandomAccessibleInterval< IntType > b = ArrayImgs.ints( 1 );
+		RandomAccessibleInterval< IntType > image = Views.stack( a, b );
+		ImgLabeling< String, IntType > labeling = new ImgLabeling<>( image );
+		Cursor< LabelingType< String > > cursor = labeling.cursor();
+		cursor.next().add( "a" );
+		cursor.next().add( "b" );
+		assertEquals( Collections.singleton( "b" ), cursor.get() );
 	}
 
 	private <T> Set<T> asSet(T... values) {


### PR DESCRIPTION
The accessors for ImgLabeling are build with the assumption that
RandomAccess.get() and Cursor.get() of the index image will always return
the same object. This constraint holds for ArrayImg and CellImg, but fails
for other RandomAccessibleIntervals like:
* ListImg,
* ConvertedRandomAccessilbeInterval,
* StackView

This commit removes the assumption, and therefor fixes ImgLabeling for the
previously mentioned RandomAccessibleIntervals.