### PR TITLE
Line iterable.

### DIFF
--- a/src/main/java/net/imglib2/roi/geom/GeomPrimitives.java
+++ b/src/main/java/net/imglib2/roi/geom/GeomPrimitives.java
@@ -1,0 +1,250 @@
+package net.imglib2.roi.geom;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import net.imglib2.AbstractCursor;
+import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RealPoint;
+
+/**
+ * Collection of static utilities related to iterating over geometry primitives.
+ * 
+ * @author Jean-Yves Tinevez
+ *
+ */
+public class GeomPrimitives
+{
+
+	/**
+	 * Returns an iterable that will iterate exactly once over all the integer
+	 * locations on a line between in proper order from the specified start to
+	 * the specified end points, included.
+	 * <p>
+	 * This implementation uses floating-point logic instead of the pure integer
+	 * logic of Bresenham line (<a href=
+	 * "https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm">Wikipedia</a>)
+	 * but the results are quasi identical and the performance penalty small.
+	 * 
+	 * @param start
+	 *            the start position.
+	 * @param end
+	 *            the end position.
+	 * @return a new iterable.
+	 */
+	public static final Iterable< Localizable > line( final Localizable start, final Localizable end )
+	{
+		if ( start.numDimensions() != end.numDimensions() )
+			throw new IllegalArgumentException( "Start and end points do not have the same number of dimensions." );
+		if ( start.numDimensions() < 1 )
+			throw new IllegalArgumentException( "Start and end points have 0 dimensions." );
+
+		return new Iterable< Localizable >()
+		{
+
+			@Override
+			public Iterator< Localizable > iterator()
+			{
+				return new LineIterator( start, end );
+			}
+		};
+	}
+
+	/**
+	 * Returns a cursor that will iterate over the specified
+	 * {@link RandomAccessible} at the locations given by the iterable, in the
+	 * order they are iterated.
+	 * 
+	 * @param randomAccessible
+	 *            the {@link RandomAccessible} to iterate over.
+	 * @param iterable
+	 *            an iterable that returns locations to iterate.
+	 * @return a new cursor.
+	 */
+	public static final < T > Cursor< T > cursor( final RandomAccessible< T > randomAccessible, final Iterable< Localizable > iterable )
+	{
+		return new MyCursor< T >( randomAccessible, iterable );
+	}
+
+	private static final class LineIterator implements Iterator< Localizable >
+	{
+
+		private final RealPoint increment;
+
+		private final RealPoint next;
+
+		private final Point current;
+
+		private final long nPoints;
+
+		private final int n;
+
+		private long index;
+
+		public LineIterator( final Localizable start, final Localizable end )
+		{
+			this.n = start.numDimensions();
+
+			final Point diff = new Point( n );
+			long maxDiff = -1;
+			for ( int d = 0; d < n; d++ )
+			{
+				final long dx = end.getLongPosition( d ) - start.getLongPosition( d );
+				diff.setPosition( dx, d );
+				if ( Math.abs( dx ) > maxDiff )
+					maxDiff = Math.abs( dx );
+			}
+			this.nPoints = maxDiff;
+
+			this.increment = new RealPoint( n );
+			for ( int d = 0; d < n; d++ )
+				increment.setPosition( diff.getDoublePosition( d ) / maxDiff, d );
+
+			this.index = -1;
+			this.current = new Point( start.numDimensions() );
+			this.next = new RealPoint( start.numDimensions() );
+			next.setPosition( start );
+		}
+
+		@Override
+		public boolean hasNext()
+		{
+			return index < nPoints;
+		}
+
+		@Override
+		public Localizable next()
+		{
+			index++;
+			if ( index < 0 || index > nPoints )
+				throw new NoSuchElementException();
+
+			for ( int d = 0; d < n; d++ )
+				current.setPosition( Math.round( next.getDoublePosition( d ) ), d );
+
+			for ( int d = 0; d < next.numDimensions(); d++ )
+				next.move( increment.getDoublePosition( d ), d );
+
+			return current;
+		}
+	}
+
+	private static final class MyCursor< T > extends AbstractCursor< T > implements Cursor< T >
+	{
+
+		private final RandomAccess< T > ra;
+
+		private Iterator< Localizable > it;
+
+		private final Iterable< Localizable > iterable;
+
+		private final RandomAccessible< T > randomAccessible;
+
+		private long index;
+
+		public MyCursor( final RandomAccessible< T > randomAccessible, final Iterable< Localizable > iterable )
+		{
+			super( randomAccessible.numDimensions() );
+			this.randomAccessible = randomAccessible;
+			this.iterable = iterable;
+			final int n = randomAccessible.numDimensions();
+			/*
+			 * Try to be clever (is this a good idea?) and determine the box in
+			 * which we will iterate before creating the randomAccess.
+			 */
+			final long[] min = new long[ n ];
+			Arrays.fill( min, Long.MAX_VALUE );
+			final long[] max = new long[ n ];
+			Arrays.fill( max, Long.MIN_VALUE );
+			for ( final Localizable p : iterable )
+			{
+				for ( int d = 0; d < n; d++ )
+				{
+					final long x = p.getLongPosition( d );
+					if ( x < min[ d ] )
+						min[ d ] = x;
+					if ( x > max[ d ] )
+						max[ d ] = x;
+				}
+			}
+			this.ra = randomAccessible.randomAccess( new FinalInterval( min, max ) );
+			reset();
+		}
+
+		@Override
+		public T get()
+		{
+			return ra.get();
+		}
+
+		@Override
+		public void fwd()
+		{
+			ra.setPosition( it.next() );
+			index++;
+		}
+
+		@Override
+		public void jumpFwd( long steps )
+		{
+			if ( steps < 1 )
+				return;
+			while ( steps > 1 )
+			{
+				steps--;
+				it.next();
+				index++;
+			}
+			fwd();
+		}
+
+		@Override
+		public void reset()
+		{
+			it = iterable.iterator();
+			index = 0;
+		}
+
+		@Override
+		public boolean hasNext()
+		{
+			return it.hasNext();
+		}
+
+		@Override
+		public void localize( final long[] position )
+		{
+			ra.localize( position );
+		}
+
+		@Override
+		public long getLongPosition( final int d )
+		{
+			return ra.getLongPosition( d );
+		}
+
+		@Override
+		public AbstractCursor< T > copy()
+		{
+			final AbstractCursor< T > copy = copyCursor();
+			copy.jumpFwd( index );
+			return copy;
+		}
+
+		@Override
+		public AbstractCursor< T > copyCursor()
+		{
+			return new MyCursor< T >( randomAccessible, iterable );
+		}
+
+	}
+
+	private GeomPrimitives()
+	{}
+}

--- a/src/main/java/net/imglib2/roi/geom/integer/Line.java
+++ b/src/main/java/net/imglib2/roi/geom/integer/Line.java
@@ -1,0 +1,299 @@
+package net.imglib2.roi.geom.integer;
+
+import java.util.Iterator;
+
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.Positionable;
+import net.imglib2.RealPoint;
+import net.imglib2.RealPositionable;
+import net.imglib2.Sampler;
+
+public class Line implements IterableInterval< Void >
+{
+
+	private final int n;
+
+	private final long nPoints;
+
+	private final Localizable start;
+
+	private final Localizable end;
+
+	public Line( final Localizable start, final Localizable end )
+	{
+		this.start = start;
+		this.end = end;
+		this.n = start.numDimensions();
+
+		final Point diff = new Point( n );
+		long maxDiff = -1;
+		for ( int d = 0; d < n; d++ )
+		{
+			final long dx = end.getLongPosition( d ) - start.getLongPosition( d );
+			diff.setPosition( dx, d );
+			if ( Math.abs( dx ) > maxDiff )
+				maxDiff = Math.abs( dx );
+		}
+		this.nPoints = maxDiff;
+	}
+
+	@Override
+	public long size()
+	{
+		return nPoints;
+	}
+
+	@Override
+	public Void firstElement()
+	{
+		return cursor().next();
+	}
+
+	@Override
+	public Object iterationOrder()
+	{
+		return this;
+	}
+
+	@Override
+	public double realMin( final int d )
+	{
+		return min( d );
+	}
+
+	@Override
+	public void realMin( final double[] min )
+	{
+		for ( int d = 0; d < n; d++ )
+			min[ d ] = realMin( d );
+	}
+
+	@Override
+	public void realMin( final RealPositionable min )
+	{
+		for ( int d = 0; d < n; d++ )
+			min.setPosition( realMin( d ), d );
+	}
+
+	@Override
+	public double realMax( final int d )
+	{
+		return max( d );
+	}
+
+	@Override
+	public void realMax( final double[] max )
+	{
+		for ( int d = 0; d < n; d++ )
+			max[ d ] = realMax( d );
+	}
+
+	@Override
+	public void realMax( final RealPositionable max )
+	{
+		for ( int d = 0; d < n; d++ )
+			max.setPosition( realMax( d ), d );
+	}
+
+	@Override
+	public int numDimensions()
+	{
+		return n;
+	}
+
+	@Override
+	public Iterator< Void > iterator()
+	{
+		return cursor();
+	}
+
+	@Override
+	public long min( final int d )
+	{
+		return Math.min( start.getLongPosition( d ), end.getLongPosition( d ) );
+	}
+
+	@Override
+	public void min( final long[] min )
+	{
+		for ( int d = 0; d < n; d++ )
+			min[ d ] = min( d );
+	}
+
+	@Override
+	public void min( final Positionable min )
+	{
+		for ( int d = 0; d < n; d++ )
+			min.setPosition( min( d ), d );
+	}
+
+	@Override
+	public long max( final int d )
+	{
+		return Math.max( start.getLongPosition( d ), end.getLongPosition( d ) );
+	}
+
+	@Override
+	public void max( final long[] max )
+	{
+		for ( int d = 0; d < n; d++ )
+			max[ d ] = max( d );
+	}
+
+	@Override
+	public void max( final Positionable max )
+	{
+		for ( int d = 0; d < n; d++ )
+			max.setPosition( max( d ), d );
+	}
+
+	@Override
+	public void dimensions( final long[] dimensions )
+	{
+		for ( int d = 0; d < n; d++ )
+			dimensions[ d ] = max( d ) - min( d );
+	}
+
+	@Override
+	public long dimension( final int d )
+	{
+		return max( d ) - min( d );
+	}
+
+	@Override
+	public Cursor< Void > cursor()
+	{
+		return cursor();
+	}
+
+	@Override
+	public Cursor< Void > localizingCursor()
+	{
+		return new LineCursor();
+	}
+
+	private final class LineCursor extends RealPoint implements Cursor< Void >
+	{
+
+		private final RealPoint increment;
+
+		private long index;
+
+		public LineCursor()
+		{
+			super( start.numDimensions() );
+
+			final Point diff = new Point( n );
+			long maxDiff = -1;
+			for ( int d = 0; d < n; d++ )
+			{
+				final long dx = end.getLongPosition( d ) - start.getLongPosition( d );
+				diff.setPosition( dx, d );
+				if ( Math.abs( dx ) > maxDiff )
+					maxDiff = Math.abs( dx );
+			}
+
+			this.increment = new RealPoint( n );
+			for ( int d = 0; d < n; d++ )
+				increment.setPosition( diff.getDoublePosition( d ) / maxDiff, d );
+
+			reset();
+		}
+
+		public LineCursor( final LineCursor c )
+		{
+			this();
+			index = c.index;
+			setPosition( c );
+		}
+
+		@Override
+		public boolean hasNext()
+		{
+			return index < nPoints;
+		}
+
+		@Override
+		public Void get()
+		{
+			return null;
+		}
+
+		@Override
+		public void fwd()
+		{
+			index++;
+			for ( int d = 0; d < n; d++ )
+				move( increment.getDoublePosition( d ), d );
+		}
+		
+
+		@Override
+		public void jumpFwd( final long steps )
+		{
+			if (steps < 0 || steps > nPoints)
+				throw new IllegalArgumentException( "Cannot jump by " + steps + " points." );
+			
+			index += steps;
+			for ( int d = 0; d < n; d++ )
+				move( steps * increment.getDoublePosition( d ), d );
+		}
+
+		@Override
+		public void reset()
+		{
+			index = -1;
+			setPosition( start );
+		}
+
+		@Override
+		public Void next()
+		{
+			fwd();
+			return null;
+		}
+
+		@Override
+		public void localize( final long[] position )
+		{
+			for ( int d = 0; d < n; d++ )
+				position[ d ] = getLongPosition( d );
+		}
+
+		@Override
+		public long getLongPosition( final int d )
+		{
+			return Math.round( getDoublePosition( d ) );
+		}
+
+
+		@Override
+		public void localize( final int[] position )
+		{
+			for ( int d = 0; d < n; d++ )
+				position[ d ] = getIntPosition( d );
+		}
+
+		@Override
+		public int getIntPosition( final int d )
+		{
+			return ( int ) getLongPosition( d );
+		}
+
+		@Override
+		public Sampler< Void > copy()
+		{
+			return new LineCursor( this );
+		}
+
+		@Override
+		public Cursor< Void > copyCursor()
+		{
+			return new LineCursor();
+		}
+	}
+
+}

--- a/src/test/java/net/imglib2/roi/geom/GeomPrimitivesLineTest.java
+++ b/src/test/java/net/imglib2/roi/geom/GeomPrimitivesLineTest.java
@@ -1,0 +1,105 @@
+package net.imglib2.roi.geom;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import net.imglib2.Cursor;
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+
+public class GeomPrimitivesLineTest
+{
+
+	@Test
+	public void testVoidLine()
+	{
+		final Point P1 = new Point( new long[] { 12, 37, 6 } );
+		final Iterable< Localizable > line = GeomPrimitives.line( P1, P1 );
+		int count = 0;
+		for ( final Localizable p : line )
+		{
+			count++;
+			for ( int d = 0; d < P1.numDimensions(); d++ )
+				assertEquals( "Unexpected position.", P1.getLongPosition( d ), p.getLongPosition( d ) );
+		}
+		assertEquals( "Should have iterated over a single point.", 1, count );
+	}
+
+	@Test
+	public void test3DLine()
+	{
+
+		// A 3D line between these 2 points:
+		final Point P1 = new Point( new long[] { 12, 37, 6 } );
+		final Point P2 = new Point( new long[] { 46, 3, 35 } );
+
+		// must iterate through ALL these points exactly, in this order:
+		final long[] X = new long[] {
+				12, 13, 14, 15, 16, 17, 18, 19, 20,
+				21, 22, 23, 24, 25, 26, 27, 28, 29,
+				30, 31, 32, 33, 34, 35, 36, 37,
+				38, 39, 40, 41, 42, 43, 44, 45, 46 };
+
+		final long[] Y = new long[] {
+				37, 36, 35, 34, 33, 32, 31, 30, 29,
+				28, 27, 26, 25, 24, 23, 22, 21, 20,
+				19, 18, 17, 16, 15, 14, 13, 12, 11,
+				10, 9, 8, 7, 6, 5, 4, 3 };
+
+		final long[] Z = new long[] {
+				6, 7, 8, 9, 9, 10, 11, 12, 13,
+				14, 15, 15, 16, 17, 18, 19, 20, 20,
+				21, 22, 23, 24, 25, 26, 26, 27, 28,
+				29, 30, 31, 32, 32, 33, 34, 35 };
+
+		// and have this much steps.
+		final long nsteps = 35;
+
+		final int targetIntensity = 1;
+
+		final ImgFactory< UnsignedByteType > imgFactory = new ArrayImgFactory<>( new UnsignedByteType() );
+		final Img< UnsignedByteType > image = imgFactory.create( 50, 50, 50 );
+
+		long count = 0;
+		final Iterable< Localizable > line = GeomPrimitives.line( P1, P2 );
+		final Cursor< UnsignedByteType > cursorLine = GeomPrimitives.cursor( image, line );
+		while ( cursorLine.hasNext() )
+		{
+			cursorLine.next().set( targetIntensity );
+			count++;
+		}
+
+		// Test if we had the same number of points
+		assertEquals( nsteps, count );
+
+		// Test if all the target points are traversed
+		final RandomAccess< UnsignedByteType > ra = image.randomAccess();
+		int totalIntensity = 0;
+		int val;
+		for ( int i = 0; i < Z.length; i++ )
+		{
+			ra.setPosition( X[ i ], 0 );
+			ra.setPosition( Y[ i ], 1 );
+			ra.setPosition( Z[ i ], 2 );
+			val = ra.get().get();
+			assertEquals( targetIntensity, val );
+			totalIntensity += val;
+		}
+
+		// Test if no other point is traversed
+		int imageSum = 0;
+		final Cursor< UnsignedByteType > cursor = image.cursor();
+		while ( cursor.hasNext() )
+		{
+			imageSum += cursor.next().get();
+		}
+
+		assertEquals( totalIntensity, imageSum );
+	}
+}


### PR DESCRIPTION
An iterable over a quasi Bresenham line. 

It will iterate exactly once over all the integer locations on a line between in proper order from the specified start to the specified end points, included.

This implementation uses floating-point logic instead of the pure integer logic of Bresenham line (Wikipedia) but the results are quasi identical and the performance penalty small.