### PR TITLE
Sparse bitmask

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,18 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 
 		<!-- Test dependencies -->
 		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.19</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.19</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -197,5 +197,10 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 			<artifactId>junit-benchmarks</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>bigdataviewer-vistools</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,12 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-vistools</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>net.imglib2</groupId>
+					<artifactId>imglib2-roi</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/net/imglib2/roi/sparse/BitMask.java
+++ b/src/main/java/net/imglib2/roi/sparse/BitMask.java
@@ -1,0 +1,205 @@
+package net.imglib2.roi.sparse;
+
+import java.util.Arrays;
+
+import net.imglib2.roi.sparse.util.BitUtils;
+import net.imglib2.util.Intervals;
+
+/**
+ * Bit-mask are stored in the leafs of the tree. Each bit-mask is a
+ * {@code leafDims}-sized boolean image backed by a {@code byte[]} array. It
+ * also keeps track of how many bits are currently set.
+ */
+class BitMask
+{
+
+	private final Specification specification;
+
+	/**
+	 * Stores data of this mask
+	 */
+	private final byte[] bytes;
+
+	/**
+	 * Current number of true bits in this mask
+	 */
+	private int numSet;
+
+	/**
+	 * Create a new BitMask that is initially completely filled with the given
+	 * value.
+	 *
+	 * @param initialValue
+	 */
+	BitMask( final Specification specification, final boolean initialValue )
+	{
+		this.specification = specification;
+		bytes = new byte[ specification.size >> 3 ];
+		if ( initialValue )
+		{
+			Arrays.fill( bytes, ( byte ) 255 );
+			numSet = specification.size;
+		}
+		else
+		{
+			numSet = 0;
+		}
+	}
+
+	/**
+	 * @param globalpos
+	 *            global position of the bit to set
+	 * @param value
+	 *            value to set the bit to
+	 * @return {@code true} iff the mask was completely filled or emptied by
+	 *         this operation
+	 */
+	boolean set( final long[] globalpos, final boolean value )
+	{
+		final int i = byteIndex( globalpos );
+		final int mask = 1 << ( globalpos[ 0 ] & specification.mask[ 0 ] & 0x07 );
+
+		final byte b = bytes[ i ];
+		if ( value )
+		{
+			final byte bm = ( byte ) ( b | mask );
+			if ( bm != b ) // changing bit from 0 to 1
+			{
+				bytes[ i ] = bm;
+				if ( ++numSet == specification.size )
+					return true;
+			}
+		}
+		else
+		{
+			final byte bm = ( byte ) ( b & ~mask );
+			if ( bm != b ) // changing bit from 1 to 0
+			{
+				bytes[ i ] = bm;
+				if ( --numSet == 0 )
+					return true;
+			}
+		}
+
+		return false;
+	}
+
+	boolean get( final long[] globalpos )
+	{
+		final byte b = bytes[ byteIndex( globalpos ) ];
+		final int mask = 1 << ( globalpos[ 0 ] & specification.mask[ 0 ] & 0x07 );
+		return ( b & mask ) != 0;
+	}
+
+	private int byteIndex( final long[] globalpos )
+	{
+		int i = 0;
+		for ( int d = specification.n - 1; d > 0; --d )
+			i = ( i + ( int ) ( globalpos[ d ] & specification.mask[ d ] ) ) * specification.byteDims[ d - 1 ];
+		return i + ( ( ( int ) ( globalpos[ 0 ] & specification.mask[ 0 ] ) ) >> 3 );
+	}
+
+	int numSet()
+	{
+		return numSet;
+	}
+
+	/**
+	 * Recompute the bounding box of true mask pixels. The result is stored in
+	 * {@code bbmin}, {@code bbmax}
+	 *
+	 * @param bbmin
+	 *            bounding box min is stored here
+	 * @param bbmax
+	 *            bounding box min is stored here
+	 * @param tmp
+	 *            temporary variable for storing positions while scanning the
+	 *            mask.
+	 */
+	void computeBoundingBox( final int[] bbmin, final int[] bbmax, final int[] tmp )
+	{
+		Arrays.fill( bbmin, Integer.MAX_VALUE );
+		Arrays.fill( bbmax, Integer.MIN_VALUE );
+		if ( numSet == 0 )
+			return;
+
+		Arrays.fill( tmp, 0 );
+		for ( int i = 0; i < bytes.length; ++i )
+		{
+			if ( bytes[ i ] != 0 )
+			{
+				for ( int d = 0; d < specification.n; ++d )
+				{
+					bbmin[ d ] = Math.min( bbmin[ d ], tmp[ d ] );
+					bbmax[ d ] = Math.max( bbmax[ d ], tmp[ d ] );
+				}
+			}
+			for ( int d = 0; d < specification.n; ++d )
+			{
+				if ( ++tmp[ d ] == specification.byteDims[ d ] )
+					tmp[ d ] = 0;
+				else
+					break;
+			}
+		}
+
+		final int step = specification.byteDims[ 0 ];
+
+		byte minproj = 0;
+		for ( int i = bbmin[ 0 ]; i < bytes.length; i += step )
+			minproj |= bytes[ i ];
+
+		byte maxproj = 0;
+		if ( bbmin[ 0 ] == bbmax[ 0 ] )
+			maxproj = minproj;
+		else
+			for ( int i = bbmax[ 0 ]; i < bytes.length; i += step )
+				maxproj |= bytes[ i ];
+
+		bbmin[ 0 ] = ( bbmin[ 0 ] << 3 ) + BitUtils.lowestOneBit( minproj );
+		bbmax[ 0 ] = ( bbmax[ 0 ] << 3 ) + BitUtils.highestOneBit( maxproj );
+	}
+
+	public static class Specification
+	{
+
+		public final int n;
+
+		/**
+		 * Mask out tile coordinate part from a position. Because leafDims are
+		 * power of 2, {@code leafMask[ d ] = leafDims[ d ] - 1}
+		 */
+		private final int[] mask;
+
+		/**
+		 * Number of bits in a leaf bit-mask.
+		 */
+		private final int size;
+
+		/**
+		 * Dimensions of a leaf bit-mask in bytes. This is the same as leafDims
+		 * (the dimensions of the bitmask), except that leafDims[0] is divided
+		 * by 8.
+		 */
+		private final int[] byteDims;
+
+		public Specification( final int[] leafDims )
+		{
+			this.n = leafDims.length;
+
+			this.mask = new int[ n ];
+			Arrays.setAll( mask, d -> leafDims[ d ] - 1 );
+			final long lsize = Intervals.numElements( leafDims );
+			this.size = toInt( lsize );
+			this.byteDims = leafDims.clone();
+			byteDims[ 0 ] = byteDims[ 0 ] >> 3;
+		}
+
+		private int toInt( final long lsize )
+		{
+			if ( lsize > Integer.MAX_VALUE )
+				throw new IllegalArgumentException();
+			return ( int ) lsize;
+		}
+	}
+}

--- a/src/main/java/net/imglib2/roi/sparse/GrowableTree.java
+++ b/src/main/java/net/imglib2/roi/sparse/GrowableTree.java
@@ -1,0 +1,266 @@
+package net.imglib2.roi.sparse;
+
+import java.util.function.Predicate;
+
+import net.imglib2.Interval;
+import net.imglib2.roi.sparse.util.DefaultInterval;
+
+/**
+ * A unbounded {@link SparseBitmaskNTree}, based on a {@link Tree} that grows
+ * when out-of-bounds pixels are set.
+ * <p>
+ * This class is not thread-safe!
+ *
+ * @author Tobias Pietzsch
+ */
+public class GrowableTree implements SparseBitmaskNTree
+{
+	private final Tree tree;
+
+	/**
+	 * Offset of position 0 in root to global coordinates. {@code offset} is a
+	 * multiple of {@code tileDims}, so that we can skip computing differences
+	 * in {@code LeafData}.
+	 */
+	private final long[] offset;
+
+	/**
+	 * @param leafDims
+	 *            Dimensions of a leaf bit-mask. <em>Every element must be a
+	 *            power of 2!</em>
+	 */
+	public GrowableTree( final int[] leafDims )
+	{
+		tree = new Tree( leafDims, 0 );
+		offset = new long[ tree.numDimensions() ];
+	}
+
+	@Override
+	public boolean get( final long[] position )
+	{
+		return get( position, new long[ numDimensions() ] );
+	}
+
+	@Override
+	public void set( final long[] position, final boolean value )
+	{
+		set( position, new long[ numDimensions() ], value );
+	}
+
+
+	/**
+	 * Set the value at the specified position. If necessary, new nodes will be
+	 * created. If possible, nodes will be merged.
+	 * <p>
+	 * {@code position} must be within bounds of this tree, i.e., within the
+	 * interval covered by the root node.
+	 *
+	 * @param position
+	 *            coordinates within bounds of this tree.
+	 * @param tmp
+	 *            pre-allocated array to store translated coordinates.
+	 * @param value
+	 *            value to store at {@code position}.
+	 */
+	public void set( final long[] position, final long[] tmp, final boolean value )
+	{
+		final int n = tree.numDimensions();
+		int childindex = 0;
+		boolean needtogrow = false;
+		for ( int d = 0; d < n; ++d )
+		{
+			final long p = position[ d ] - offset[ d ];
+			tmp[ d ] = p;
+			needtogrow = needtogrow || p < 0 || p > tree.bounds().max( d );
+			if ( p < 0 )
+			{
+				childindex |= 1 << d;
+				offset[ d ] -= tree.bounds().dimension( d );
+			}
+		}
+		if ( needtogrow )
+		{
+			if ( value )
+			{
+				tree.grow( childindex );
+				set( position, tmp, value );
+			}
+		}
+		else
+			tree.set( tmp, value );
+	}
+
+	/**
+	 * Get the value at the specified position.
+	 * <p>
+	 * {@code position} must be within bounds of this tree, i.e., within the
+	 * interval covered by the root node.
+	 *
+	 * @param position
+	 *            coordinates within bounds of this tree.
+	 * @param tmp
+	 *            pre-allocated array to store translated coordinates.
+	 * @return the value at {@code position}.
+	 */
+	public boolean get( final long[] position, final long[] tmp )
+	{
+		final int n = tree.numDimensions();
+		for ( int d = 0; d < n; ++d )
+		{
+			final long p = position[ d ] - offset[ d ];
+			if ( p < 0 || p > tree.bounds().max( d ) )
+				return false;
+			tmp[ d ] = p;
+		}
+		return tree.get( tmp );
+	}
+
+	/**
+	 * Returns the current height of the tree.
+	 * <p>
+	 * The height is the length of the path from the root to a leaf (containing
+	 * a bit mask). E.g., a tree comprising only a root nodeData has
+	 * {@code height = 0}.
+	 *
+	 * @return the current height of the tree.
+	 */
+	@Override
+	public int height()
+	{
+		return tree.height();
+	}
+
+	@Override
+	public int numDimensions()
+	{
+		return tree.numDimensions();
+	}
+
+	@Override
+	public void forEach( final Predicate< Node > op )
+	{
+		final NodeImp w = new NodeImp();
+		tree.forEach( ( final Node nd ) -> op.test( w.wrap( nd ) ) );
+	}
+
+	@Override
+	public NodeIterator iterator()
+	{
+		return new NodeIteratorImp();
+	}
+
+	private class NodeIteratorImp implements NodeIterator
+	{
+		private final NodeImp w = new NodeImp();
+
+		private final NodeIterator wi;
+
+		NodeIteratorImp()
+		{
+			wi = tree.iterator();
+		}
+
+		NodeIteratorImp( final NodeIteratorImp other )
+		{
+			wi = other.wi.copy();
+		}
+
+		@Override
+		public void reset()
+		{
+			wi.reset();
+		}
+
+		@Override
+		public boolean hasNext()
+		{
+			return wi.hasNext();
+		}
+
+		@Override
+		public Node next()
+		{
+			return w.wrap( wi.next() );
+		}
+
+		@Override
+		public Node current()
+		{
+			return w.wrap( wi.current() );
+		}
+
+		@Override
+		public NodeIterator copy()
+		{
+			return new NodeIteratorImp( this );
+		}
+	}
+
+	private class NodeImp implements Node
+	{
+		private Node source;
+
+		Node wrap( final Node source )
+		{
+			this.source = source;
+			return this;
+		}
+
+		private final Interval interval = new DefaultInterval()
+		{
+			@Override
+			public long min( final int d )
+			{
+				return source.interval().min( d ) + offset[ d ];
+			}
+
+			@Override
+			public long max( final int d )
+			{
+				return source.interval().max( d ) + offset[ d ];
+			}
+
+			@Override
+			public long dimension( final int d )
+			{
+				return source.interval().dimension( d );
+			}
+
+			@Override
+			public int numDimensions()
+			{
+				return source.interval().numDimensions();
+			}
+		};
+
+		@Override
+		public boolean hasChildren()
+		{
+			return source.hasChildren();
+		}
+
+		@Override
+		public boolean value()
+		{
+			return source.value();
+		}
+
+		@Override
+		public Tree.BitMask bitmask()
+		{
+			return source.bitmask();
+		}
+
+		@Override
+		public Interval interval()
+		{
+			return interval;
+		}
+
+		@Override
+		public int level()
+		{
+			return source.level();
+		}
+	}
+}

--- a/src/main/java/net/imglib2/roi/sparse/GrowableTree.java
+++ b/src/main/java/net/imglib2/roi/sparse/GrowableTree.java
@@ -246,7 +246,7 @@ public class GrowableTree implements SparseBitmaskNTree
 		}
 
 		@Override
-		public BitMask bitmask()
+		public LeafBitmask bitmask()
 		{
 			return source.bitmask();
 		}

--- a/src/main/java/net/imglib2/roi/sparse/GrowableTree.java
+++ b/src/main/java/net/imglib2/roi/sparse/GrowableTree.java
@@ -9,7 +9,7 @@ import net.imglib2.roi.sparse.util.DefaultInterval;
  * A unbounded {@link SparseBitmaskNTree}, based on a {@link Tree} that grows
  * when out-of-bounds pixels are set.
  * <p>
- * This class is not thread-safe!
+ * This class is thread-safe!
  *
  * @author Tobias Pietzsch
  */
@@ -54,7 +54,7 @@ public class GrowableTree implements SparseBitmaskNTree
 	 * @param value
 	 *            value to store at {@code position}.
 	 */
-	public void set( final long[] position, final long[] tmp, final boolean value )
+	public synchronized void set( final long[] position, final long[] tmp, final boolean value )
 	{
 		final TreeAndOffset o = treeAndOffset;
 		final int n = o.tree.numDimensions();

--- a/src/main/java/net/imglib2/roi/sparse/GrowableTree.java
+++ b/src/main/java/net/imglib2/roi/sparse/GrowableTree.java
@@ -15,7 +15,7 @@ import net.imglib2.roi.sparse.util.DefaultInterval;
  */
 public class GrowableTree implements SparseBitmaskNTree
 {
-	private final Tree tree;
+	private Tree tree;
 
 	/**
 	 * Offset of position 0 in root to global coordinates. {@code offset} is a
@@ -82,7 +82,7 @@ public class GrowableTree implements SparseBitmaskNTree
 		{
 			if ( value )
 			{
-				tree.grow( childindex );
+				tree = Tree.newParentTree( tree, childindex );
 				set( position, tmp, value );
 			}
 		}

--- a/src/main/java/net/imglib2/roi/sparse/GrowableTree.java
+++ b/src/main/java/net/imglib2/roi/sparse/GrowableTree.java
@@ -246,7 +246,7 @@ public class GrowableTree implements SparseBitmaskNTree
 		}
 
 		@Override
-		public Tree.BitMask bitmask()
+		public BitMask bitmask()
 		{
 			return source.bitmask();
 		}

--- a/src/main/java/net/imglib2/roi/sparse/LeafBitmask.java
+++ b/src/main/java/net/imglib2/roi/sparse/LeafBitmask.java
@@ -11,7 +11,7 @@ import net.imglib2.util.Intervals;
  * Bitmask is NOT THREADSAFE.
  * Bitmask is periodically extended comparable to {@link net.imglib2.view.Views#extendPeriodic}.
  */
-class BitMask
+class LeafBitmask
 {
 
 	private final Specification specification;
@@ -32,7 +32,7 @@ class BitMask
 	 *
 	 * @param initialValue
 	 */
-	public BitMask( final Specification specification, final boolean initialValue )
+	public LeafBitmask( final Specification specification, final boolean initialValue )
 	{
 		this.specification = specification;
 		data = new byte[ specification.size >> 3 ];

--- a/src/main/java/net/imglib2/roi/sparse/NodeData.java
+++ b/src/main/java/net/imglib2/roi/sparse/NodeData.java
@@ -72,7 +72,7 @@ class NodeData
 		return value;
 	}
 
-	public LeafBitmask data()
+	public LeafBitmask bitmask()
 	{
 		return data;
 	}

--- a/src/main/java/net/imglib2/roi/sparse/NodeData.java
+++ b/src/main/java/net/imglib2/roi/sparse/NodeData.java
@@ -1,0 +1,89 @@
+package net.imglib2.roi.sparse;
+
+class NodeData
+{
+	// The value, represented only counts if data and children are zero
+	private boolean value;
+
+	private LeafBitmask data;
+
+	private NodeData parent;
+
+	private NodeData[] children;
+
+	NodeData( final NodeData parent, final boolean value )
+	{
+		this.parent = parent;
+		this.value = value;
+	}
+
+	boolean hasChildren()
+	{
+		return children != null;
+	}
+
+	public void createChildren( final int numChildren ) {
+		NodeData[] children = new NodeData[ numChildren ];
+		for ( int i = 0; i < numChildren; ++i )
+			children[ i ] = new NodeData( this, value );
+		// NB: One atomic operation, that doesn't change the Bitmask represented.
+		this.children = children;
+	}
+
+	public void createBitmask( LeafBitmask.Specification bitmaskSpecification )
+	{
+		// NB: One atomic operation, that doesn't change the Bitmask represented.
+		data = new LeafBitmask( bitmaskSpecification, value );
+	}
+
+	public NodeData newParent( final int childindex, final int numChildren )
+	{
+		NodeData newRoot = new NodeData( null, false );
+		newRoot.children = new NodeData[ numChildren ];
+		for ( int i = 0; i < numChildren; ++i )
+			newRoot.children[ i ] = ( i == childindex )
+					? this : new NodeData( newRoot, false );
+		this.parent = newRoot;
+		return newRoot;
+	}
+
+	public boolean merge( final boolean value )
+	{
+		for ( NodeData child : children )
+		{
+			if ( child.hasChildren() || child.data != null || child.value != value )
+				return false;
+		}
+		// NB: Two operations, that doesn't change the Bitmask represented.
+		this.value = value;
+		this.children = null;
+		return true;
+	}
+
+	public void mergeLeafToValue( boolean value )
+	{
+		this.value = value;
+		// NB: One atomic change, that set's all pixels represented by the lead two value
+		this.data = null;
+	}
+
+	public boolean value()
+	{
+		return value;
+	}
+
+	public LeafBitmask data()
+	{
+		return data;
+	}
+
+	public NodeData parent()
+	{
+		return parent;
+	}
+
+	public NodeData child( int i )
+	{
+		return children[ i ];
+	}
+}

--- a/src/main/java/net/imglib2/roi/sparse/NodeData.java
+++ b/src/main/java/net/imglib2/roi/sparse/NodeData.java
@@ -84,6 +84,7 @@ class NodeData
 
 	public NodeData child( int i )
 	{
-		return children[ i ];
+		final NodeData[] children = this.children;
+		return children != null ? children[ i ] : null;
 	}
 }

--- a/src/main/java/net/imglib2/roi/sparse/NodeData.java
+++ b/src/main/java/net/imglib2/roi/sparse/NodeData.java
@@ -60,7 +60,7 @@ class NodeData
 		return true;
 	}
 
-	public void mergeLeafToValue( boolean value )
+	public void mergeLeafToValue( final boolean value )
 	{
 		this.value = value;
 		// NB: One atomic change, that set's all pixels represented by the lead two value

--- a/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
+++ b/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
@@ -1,0 +1,478 @@
+package net.imglib2.roi.sparse;
+
+import java.util.Arrays;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import net.imglib2.AbstractLocalizable;
+import net.imglib2.Cursor;
+import net.imglib2.Interval;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.img.basictypeaccess.BooleanAccess;
+import net.imglib2.roi.IterableRegion;
+import net.imglib2.roi.sparse.SparseBitmaskNTree.Node;
+import net.imglib2.roi.sparse.SparseBitmaskNTree.NodeIterator;
+import net.imglib2.roi.sparse.Tree.BitMask;
+import net.imglib2.roi.sparse.util.DefaultInterval;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.util.Intervals;
+
+/**
+ * A (unbounded) {@code RandomAccessible<NativeBoolType>}.
+ * <p>
+ * Use {@link #region()} to obtain a (read-only) view as an
+ * {@link IterableRegion}.
+ *
+ * @author Tobias Pietzsch
+ */
+public class SparseBitmask implements RandomAccessible< NativeBoolType >
+{
+	private final GrowableTree tree;
+
+	private final ReentrantReadWriteLock lock;
+
+	private int modCount;
+
+	public SparseBitmask(
+			final int numDimensions )
+	{
+		final int[] leafDims = new int[ numDimensions ];
+		Arrays.fill( leafDims, 8 );
+		tree = new GrowableTree( leafDims );
+		lock = new ReentrantReadWriteLock();
+	}
+
+	public SparseBitmaskNTree tree()
+	{
+		return tree;
+	}
+
+	/**
+	 * Get a view of this {@code SparseBitmask} as an {@code IterableRegion}.
+	 * The view is read-only, and is only valid while the bitmask is not modified.
+	 * After writing to the bitmask, using the {@code IterableRegion} results in {@link ConcurrentModificationException}.
+	 *
+	 * @return a read-only view of this {@code SparseBitmask}.
+	 */
+	public IterableRegion< NativeBoolType > region()
+	{
+		return new Region();
+	}
+
+	/*
+	 *
+	 * RandomAccessible< NativeBoolType >
+	 *
+	 */
+
+	@Override
+	public int numDimensions()
+	{
+		return tree.numDimensions();
+	}
+
+	@Override
+	public RandomAccess< NativeBoolType > randomAccess()
+	{
+		return new RA();
+	}
+
+	@Override
+	public RandomAccess< NativeBoolType > randomAccess( final Interval interval )
+	{
+		return randomAccess();
+	}
+
+	private class Access implements BooleanAccess
+	{
+		private final long[] tmp;
+
+		private final long[] position;
+
+		Access( final long[] position )
+		{
+			this.position = position;
+			tmp = new long[ position.length ];
+		}
+
+		@Override
+		public boolean getValue( final int index )
+		{
+			try
+			{
+				lock.readLock().lock();
+				return tree.get( position, tmp );
+			}
+			finally
+			{
+				lock.readLock().unlock();
+			}
+		}
+
+		@Override
+		public void setValue( final int index, final boolean value )
+		{
+			try
+			{
+				lock.writeLock().lock();
+				tree.set( position, tmp, value );
+				++modCount;
+			}
+			finally
+			{
+				lock.writeLock().unlock();
+			}
+		}
+	}
+
+	private class RA extends Point implements RandomAccess< NativeBoolType >
+	{
+		private final NativeBoolType type;
+
+		RA()
+		{
+			super( tree.numDimensions() );
+			type = new NativeBoolType( new Access( position ) );
+		}
+
+		@Override
+		public NativeBoolType get()
+		{
+			return type;
+		}
+
+		@Override
+		public RA copyRandomAccess()
+		{
+			return copy();
+		}
+
+		@Override
+		public RA copy()
+		{
+			final RA copy = new RA();
+			localize( copy.position );
+			return copy;
+		}
+	}
+
+	/*
+	 *
+	 * IterableRegion< NativeBoolType >
+	 *
+	 */
+
+	private class ReadOnlyAccess implements BooleanAccess
+	{
+		private final long[] tmp;
+
+		private final long[] position;
+
+		ReadOnlyAccess( final long[] position )
+		{
+			this.position = position;
+			tmp = new long[ position.length ];
+		}
+
+		@Override
+		public boolean getValue( final int index )
+		{
+			return tree.get( position, tmp );
+		}
+
+		@Override
+		public void setValue( final int index, final boolean value )
+		{
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private class Region implements IterableRegion< NativeBoolType >, DefaultInterval
+	{
+		private Interval bbox;
+
+		private long size = -1;
+
+		private int expectedModCount = modCount;
+
+		private void checkForComodification()
+		{
+			if ( modCount != expectedModCount )
+				throw new ConcurrentModificationException();
+		}
+
+		private void checkModifications()
+		{
+			bbox = SparseBitmaskNTree.bbox( tree );
+			size = SparseBitmaskNTree.size( tree );
+			expectedModCount = modCount;
+		}
+
+		@Override
+		public int numDimensions()
+		{
+			return tree.numDimensions();
+		}
+
+		@Override
+		public Cursor< Void > cursor()
+		{
+			checkForComodification();
+			return new TrueCursor();
+		}
+
+		@Override
+		public Cursor< Void > localizingCursor()
+		{
+			return cursor();
+		}
+
+		@Override
+		public long size()
+		{
+			checkForComodification();
+			if ( size < 0 )
+				size = SparseBitmaskNTree.size( tree );
+			return size;
+		}
+
+		@Override
+		public Void firstElement()
+		{
+			return null;
+		}
+
+		@Override
+		public Object iterationOrder()
+		{
+			return this;
+		}
+
+		@Override
+		public Iterator< Void > iterator()
+		{
+			return cursor();
+		}
+
+		@Override
+		public long min( final int d )
+		{
+			checkForComodification();
+			if ( bbox == null )
+				bbox = SparseBitmaskNTree.bbox( tree );
+			return bbox.min( d );
+		}
+
+		@Override
+		public long max( final int d )
+		{
+			checkForComodification();
+			if ( bbox == null )
+				bbox = SparseBitmaskNTree.bbox( tree );
+			return bbox.max( d );
+		}
+
+		@Override
+		public long dimension( final int d )
+		{
+			checkForComodification();
+			if ( bbox == null )
+				bbox = SparseBitmaskNTree.bbox( tree );
+			return bbox.dimension( d );
+		}
+
+		@Override
+		public RandomAccess< NativeBoolType > randomAccess()
+		{
+			return new RA();
+		}
+
+		@Override
+		public RandomAccess< NativeBoolType > randomAccess( final Interval interval )
+		{
+			return randomAccess();
+		}
+
+		private class RA extends Point implements RandomAccess< NativeBoolType >
+		{
+			private final NativeBoolType type;
+
+			RA()
+			{
+				super( tree.numDimensions() );
+				type = new NativeBoolType( new ReadOnlyAccess( position ) );
+			}
+
+			@Override
+			public NativeBoolType get()
+			{
+				checkForComodification();
+				return type;
+			}
+
+			@Override
+			public RA copyRandomAccess()
+			{
+				return copy();
+			}
+
+			@Override
+			public RA copy()
+			{
+				final RA copy = new RA();
+				localize( copy.position );
+				return copy;
+			}
+
+		}
+
+		private class TrueCursor extends AbstractLocalizable implements Cursor< Void >
+		{
+			private final NodeIterator iter;
+
+			private final long[] nodeMin;
+
+			private final long[] nodeMax;
+
+			private Node nextNode;
+
+			private int currentSize;
+
+			private int currentIndex;
+
+			private BitMask currentMask;
+
+			TrueCursor()
+			{
+				super( tree.numDimensions() );
+				iter = tree.iterator();
+				nodeMin = new long[ n ];
+				nodeMax = new long[ n ];
+				nextNode = nextNonEmptyNode();
+				currentSize = 0;
+				currentIndex = 0;
+			}
+
+			private TrueCursor( final TrueCursor other )
+			{
+				super( other.numDimensions() );
+				other.localize( position );
+				iter = other.iter.copy();
+				nodeMin = other.nodeMin.clone();
+				nodeMax = other.nodeMax.clone();
+				nextNode = iter.current();
+				currentSize = other.currentSize;
+				currentIndex = other.currentIndex;
+				currentMask = other.currentMask;
+			}
+
+			private Node nextNonEmptyNode()
+			{
+				while ( iter.hasNext() )
+				{
+					final Node nd = iter.next();
+					if ( ( !nd.hasChildren() && nd.value() ) || nd.hasBitMask() )
+						return nd;
+				}
+				return null;
+			}
+
+			@Override
+			public void reset()
+			{
+				iter.reset();
+				nextNode = nextNonEmptyNode();
+				currentIndex = 0;
+				currentSize = 0;
+			}
+
+			@Override
+			public boolean hasNext()
+			{
+				return currentIndex < currentSize || nextNode != null;
+			}
+
+			@Override
+			public void fwd()
+			{
+				checkForComodification();
+				if ( ++currentIndex < currentSize )
+				{
+					if ( currentMask == null )
+						advance();
+					else
+						do
+							advance();
+						while ( !currentMask.get( position ) );
+				}
+				else
+				{
+					if ( nextNode != null )
+					{
+						nextNode.interval().min( nodeMin );
+						nextNode.interval().max( nodeMax );
+						System.arraycopy( nodeMin, 0, position, 0, n );
+						if ( nextNode.hasBitMask() )
+						{
+							currentMask = nextNode.bitmask();
+							currentSize = currentMask.numSet();
+							while ( !currentMask.get( position ) )
+								advance();
+						}
+						else
+						{
+							currentMask = null;
+							currentSize = ( int ) Intervals.numElements( nextNode.interval() );
+						}
+						currentIndex = 0;
+						nextNode = nextNonEmptyNode();
+					}
+				}
+			}
+
+			private void advance()
+			{
+				for ( int d = 0; d < n; ++d )
+					if ( ++position[ d ] > nodeMax[ d ] )
+						position[ d ] = nodeMin[ d ];
+					else
+						break;
+			}
+
+			@Override
+			public void jumpFwd( final long steps )
+			{
+				for ( long i = 0; i < steps; ++i )
+					fwd();
+			}
+
+			@Override
+			public Void get()
+			{
+				return null;
+			}
+
+			@Override
+			public Void next()
+			{
+				fwd();
+				return null;
+			}
+
+			@Override
+			public TrueCursor copy()
+			{
+				return new TrueCursor( this );
+			}
+
+			@Override
+			public TrueCursor copyCursor()
+			{
+				return copy();
+			}
+		}
+	}
+}

--- a/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
+++ b/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
@@ -15,7 +15,6 @@ import net.imglib2.img.basictypeaccess.BooleanAccess;
 import net.imglib2.roi.IterableRegion;
 import net.imglib2.roi.sparse.SparseBitmaskNTree.Node;
 import net.imglib2.roi.sparse.SparseBitmaskNTree.NodeIterator;
-import net.imglib2.roi.sparse.Tree.BitMask;
 import net.imglib2.roi.sparse.util.DefaultInterval;
 import net.imglib2.type.logic.NativeBoolType;
 import net.imglib2.util.Intervals;

--- a/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
+++ b/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
@@ -31,8 +31,6 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 {
 	private final GrowableTree tree;
 
-	private final ReentrantReadWriteLock lock;
-
 	private int modCount;
 
 	public SparseBitmask(
@@ -41,7 +39,6 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 		final int[] leafDims = new int[ numDimensions ];
 		Arrays.fill( leafDims, 8 );
 		tree = new GrowableTree( leafDims );
-		lock = new ReentrantReadWriteLock();
 	}
 
 	public SparseBitmaskNTree tree()
@@ -100,30 +97,14 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 		@Override
 		public boolean getValue( final int index )
 		{
-			try
-			{
-				lock.readLock().lock();
-				return tree.get( position, tmp );
-			}
-			finally
-			{
-				lock.readLock().unlock();
-			}
+			return tree.get( position, tmp );
 		}
 
 		@Override
 		public void setValue( final int index, final boolean value )
 		{
-			try
-			{
-				lock.writeLock().lock();
-				tree.set( position, tmp, value );
-				++modCount;
-			}
-			finally
-			{
-				lock.writeLock().unlock();
-			}
+			tree.set( position, tmp, value );
+			++modCount;
 		}
 	}
 

--- a/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
+++ b/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
@@ -205,7 +205,7 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 
 		private void checkModifications()
 		{
-			bbox = SparseBitmaskNTree.bbox( tree );
+			bbox = SparseBitmaskNTree.boundingBox( tree );
 			size = SparseBitmaskNTree.size( tree );
 			expectedModCount = modCount;
 		}
@@ -261,7 +261,7 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 		{
 			checkForComodification();
 			if ( bbox == null )
-				bbox = SparseBitmaskNTree.bbox( tree );
+				bbox = SparseBitmaskNTree.boundingBox( tree );
 			return bbox.min( d );
 		}
 
@@ -270,7 +270,7 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 		{
 			checkForComodification();
 			if ( bbox == null )
-				bbox = SparseBitmaskNTree.bbox( tree );
+				bbox = SparseBitmaskNTree.boundingBox( tree );
 			return bbox.max( d );
 		}
 
@@ -279,7 +279,7 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 		{
 			checkForComodification();
 			if ( bbox == null )
-				bbox = SparseBitmaskNTree.bbox( tree );
+				bbox = SparseBitmaskNTree.boundingBox( tree );
 			return bbox.dimension( d );
 		}
 

--- a/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
+++ b/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
@@ -338,7 +338,7 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 
 			private Node nextNode;
 
-			private int currentSize;
+			private int currentMax;
 
 			private int currentIndex;
 
@@ -351,7 +351,7 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 				nodeMin = new long[ n ];
 				nodeMax = new long[ n ];
 				nextNode = nextNonEmptyNode();
-				currentSize = 0;
+				currentMax = 0;
 				currentIndex = 0;
 			}
 
@@ -363,7 +363,7 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 				nodeMin = other.nodeMin.clone();
 				nodeMax = other.nodeMax.clone();
 				nextNode = iter.current();
-				currentSize = other.currentSize;
+				currentMax = other.currentMax;
 				currentIndex = other.currentIndex;
 				currentMask = other.currentMask;
 			}
@@ -385,21 +385,22 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 				iter.reset();
 				nextNode = nextNonEmptyNode();
 				currentIndex = 0;
-				currentSize = 0;
+				currentMax = 0;
 			}
 
 			@Override
 			public boolean hasNext()
 			{
-				return currentIndex < currentSize || nextNode != null;
+				return currentIndex < currentMax || nextNode != null;
 			}
 
 			@Override
 			public void fwd()
 			{
 				checkForComodification();
-				if ( ++currentIndex < currentSize )
+				if ( currentIndex < currentMax )
 				{
+					++currentIndex;
 					if ( currentMask == null )
 						advance();
 					else
@@ -417,14 +418,14 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 						if ( nextNode.hasBitMask() )
 						{
 							currentMask = nextNode.bitmask();
-							currentSize = currentMask.numSet();
+							currentMax = currentMask.numSet() - 1;
 							while ( !currentMask.get( position ) )
 								advance();
 						}
 						else
 						{
 							currentMask = null;
-							currentSize = ( int ) Intervals.numElements( nextNode.interval() );
+							currentMax = ( int ) Intervals.numElements( nextNode.interval() ) - 1;
 						}
 						currentIndex = 0;
 						nextNode = nextNonEmptyNode();

--- a/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
+++ b/src/main/java/net/imglib2/roi/sparse/SparseBitmask.java
@@ -342,7 +342,7 @@ public class SparseBitmask implements RandomAccessible< NativeBoolType >
 
 			private int currentIndex;
 
-			private BitMask currentMask;
+			private LeafBitmask currentMask;
 
 			TrueCursor()
 			{

--- a/src/main/java/net/imglib2/roi/sparse/SparseBitmaskNTree.java
+++ b/src/main/java/net/imglib2/roi/sparse/SparseBitmaskNTree.java
@@ -111,7 +111,7 @@ public interface SparseBitmaskNTree extends EuclideanSpace, Iterable< Node >
 		/**
 		 * internal
 		 */
-		BitMask bitmask();
+		LeafBitmask bitmask();
 
 		/**
 		 * Get the coordinate interval covered by this node.

--- a/src/main/java/net/imglib2/roi/sparse/SparseBitmaskNTree.java
+++ b/src/main/java/net/imglib2/roi/sparse/SparseBitmaskNTree.java
@@ -8,7 +8,6 @@ import net.imglib2.EuclideanSpace;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.roi.sparse.SparseBitmaskNTree.Node;
-import net.imglib2.roi.sparse.Tree.BitMask;
 import net.imglib2.util.Intervals;
 
 /**

--- a/src/main/java/net/imglib2/roi/sparse/SparseBitmaskNTree.java
+++ b/src/main/java/net/imglib2/roi/sparse/SparseBitmaskNTree.java
@@ -1,0 +1,338 @@
+package net.imglib2.roi.sparse;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+import net.imglib2.EuclideanSpace;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.roi.sparse.SparseBitmaskNTree.Node;
+import net.imglib2.roi.sparse.Tree.BitMask;
+import net.imglib2.util.Intervals;
+
+/**
+ * A bitmask stored as a quadtree (or n-dimensional equivalent). The tree is
+ * truncated such that it does not contain boolean value-nodes all the way to
+ * the leafs. Instead, leafs store bitmasks of a specified size.
+ *
+ * @author Tobias Pietzsch
+ */
+public interface SparseBitmaskNTree extends EuclideanSpace, Iterable< Node >
+{
+	/**
+	 * Get the height of the tree.
+	 * <p>
+	 * The height is the (assumed) length of the path from the root to a leaf
+	 * containing a bit mask. E.g., a tree comprising only a root node has
+	 * {@code height = 0}.
+	 *
+	 * @return the current height of the tree.
+	 */
+	int height();
+
+	/**
+	 * Get the value at the specified position.
+	 * <p>
+	 * {@code position} must be within bounds of this tree, i.e., within the
+	 * interval covered by the root node.
+	 *
+	 * @param position
+	 *            coordinates within bounds of this tree.
+	 * @return the value at {@code position}.
+	 */
+	boolean get( final long[] position );
+
+	/**
+	 * Set the value at the specified position. If necessary, new nodes will be
+	 * created. If possible, nodes will be merged.
+	 * <p>
+	 * {@code position} must be within bounds of this tree, i.e., within the
+	 * interval covered by the root node.
+	 *
+	 * @param position
+	 *            coordinates within bounds of this tree.
+	 * @param value
+	 *            value to store at {@code position}.
+	 */
+	void set( final long[] position, final boolean value );
+
+	/**
+	 * Evaluates {@code op} for each node, traversing the tree depth-first. If
+	 * {@code op} returns {@code false} for a node, the branch below the node is
+	 * truncated.
+	 *
+	 * @param op
+	 *            evaluated for each node
+	 */
+	void forEach( final Predicate< Node > op );
+
+	/**
+	 * Returns a {@link NodeIterator} that iterates the nodes of this tree using
+	 * depth first traversal.
+	 *
+	 * @return a node iterator.
+	 */
+	@Override
+	NodeIterator iterator();
+
+	interface Node
+	{
+		/**
+		 * Returns {@code true}, iff this node has children.
+		 * <p>
+		 * Nodes without children are either completely {@code true} or
+		 * {@code false} (see {@link #value()}) or have values specified by a
+		 * {@link #bitmask()}.
+		 *
+		 * @return whether this node has children.
+		 */
+		boolean hasChildren();
+
+		/**
+		 * Returns {@code true}, iff this node has a bitmask. (This implies
+		 * {@code hasCildren() == false}).
+		 *
+		 * @return whether this node has a bitmask.
+		 */
+		default boolean hasBitMask()
+		{
+			return bitmask() != null;
+		}
+
+		/**
+		 * Get the value of this node, i.e. ,the value of all voxels covered by
+		 * this node. The returned value is meaningless if this node has
+		 * children or an associated bitmask.
+		 *
+		 * @return the value of this node.
+		 */
+		boolean value();
+
+		/**
+		 * internal
+		 */
+		BitMask bitmask();
+
+		/**
+		 * Get the coordinate interval covered by this node.
+		 *
+		 * @return interval covered by this node.
+		 */
+		Interval interval();
+
+		/**
+		 * Get the <em>level</em> of this node.
+		 * <p>
+		 * </p>
+		 * The level of a node corresponds to its height in a fully populated
+		 * tree. I.e., the level of a node is the height of the tree (with at
+		 * least one bit mask) minus the depth of the node. For example, leaf
+		 * nodes in the fully populated tree have level {@code 0}. The root node
+		 * has level {@link #height()}.
+		 *
+		 * @return the level of this node
+		 */
+		int level();
+	}
+
+	/**
+	 * Iterates the nodes of a {@link SparseBitmaskNTree} using depth first
+	 * traversal.
+	 */
+	interface NodeIterator extends Iterator< Node >
+	{
+		void reset();
+
+		/**
+		 * Get an independent copy that is pointing to the same node as this
+		 * iterator.
+		 *
+		 * @return copy of this iterator.
+		 */
+		NodeIterator copy();
+
+		/**
+		 * Get the node returned by the most recent {@link #next()}.
+		 *
+		 * @return the node returned by the most recent {@link #next()}.
+		 */
+		Node current();
+	}
+
+	/*
+	 *
+	 * Simple algorithms on SparseBitmaskNTree
+	 *
+	 */
+
+	/**
+	 * Compute the number of {@code true} pixels in a {@link SparseBitmaskNTree}.
+	 *
+	 * @param tree a {@code SparseBitmaskNTree}
+	 * @return the number of {@code true} pixels in a {@code tree}.
+	 */
+	static long size( final SparseBitmaskNTree tree )
+	{
+		long size = 0;
+		final NodeIterator iter = tree.iterator();
+		while ( iter.hasNext() )
+		{
+			final Node nd = iter.next();
+			if ( !nd.hasChildren() )
+			{
+				if ( nd.hasBitMask() )
+					size += nd.bitmask().numSet();
+				else if ( nd.value() )
+					size += Intervals.numElements( nd.interval() );
+			}
+		}
+		return size;
+	}
+
+	/**
+	 * Compute the bounding box of {@code true} pixels in a {@link SparseBitmaskNTree}.
+	 * <p>
+	 * This does an iteratively deepening search on the tree nodes, at each level
+	 * refining an inner and outer bounding box. The inner bounding box is the
+	 * smallest bounding box that is possible, considering data from nodes up to
+	 * the current level
+	 *
+	 * @param tree a {@code SparseBitmaskNTree}
+	 * @return the bounding box of {@code true} pixels in a {@code tree}.
+	 */
+	static Interval bbox( final SparseBitmaskNTree tree )
+	{
+		final int n = tree.numDimensions();
+
+		// skip nodes completely outside this bbox
+		// (this is the outer bbox of the previous height)
+		final long[] truncMin = new long[ n ];
+		final long[] truncMax = new long[ n ];
+		// initially trunc bbox contains everything
+		Arrays.fill( truncMin, Long.MIN_VALUE );
+		Arrays.fill( truncMax, Long.MAX_VALUE );
+
+		// largest bbox still possible
+		final long[] outerMin = new long[ n ];
+		final long[] outerMax = new long[ n ];
+
+		// smallest bbox still possible
+		final long[] innerMin = new long[ n ];
+		final long[] innerMax = new long[ n ];
+		// initially smallest bbox is empty
+		Arrays.fill( innerMin, Long.MAX_VALUE );
+		Arrays.fill( innerMax, Long.MIN_VALUE );
+
+		// reused to store bboxes of leaf masks
+		final int[] leafbbmin = new int[ n ];
+		final int[] leafbbmax = new int[ n ];
+		final int[] leafbbtmp = new int[ n ];
+
+		for ( int i = 0; i <= tree.height(); ++i )
+		{
+			// initialize outer bbox to inner bbox from last iteration.
+			// from there, it will grow to true and mixed nodes.
+			System.arraycopy( innerMin, 0, outerMin, 0, n );
+			System.arraycopy( innerMax, 0, outerMax, 0, n );
+
+			final int l = tree.height() - i;
+
+			// iter nodes at tree level l
+			tree.forEach( node -> {
+				final int level = node.level();
+				final Interval nodei = node.interval();
+
+				// if nodei is completely outside outer bb, do not recurse further
+				boolean intersectsTrunc = true;
+				for ( int d = 0; d < n; ++d )
+				{
+					final long imin = Math.max( truncMin[ d ], nodei.min( d ) );
+					final long imax = Math.min( truncMax[ d ], nodei.max( d ) );
+					if ( imax < imin )
+					{
+						intersectsTrunc = false;
+						break;
+					}
+				}
+				if ( !intersectsTrunc )
+					return false;
+
+				// if nodei is completely contained in inner bb, do not recurse further
+				boolean containedInInner = true;
+				for ( int d = 0; d < n; ++d )
+				{
+					if ( innerMin[ d ] > nodei.min( d ) || innerMax[ d ] < nodei.max( d ) )
+					{
+						containedInInner = false;
+						break;
+					}
+				}
+				if ( containedInInner )
+					return false;
+
+				// if node is above level l, do not modify bounding box
+				// (the node has already been taken into account)
+				if ( level > l )
+					return true;
+
+				if ( node.hasChildren() )
+				{
+					for ( int d = 0; d < n; ++d )
+					{
+						if ( nodei.min( d ) < outerMin[ d ] )
+							outerMin[ d ] = nodei.min( d );
+						if ( nodei.max( d ) > outerMax[ d ] )
+							outerMax[ d ] = nodei.max( d );
+
+						// TODO: is the +1/-1 required here?
+						if ( nodei.max( d ) + 1 < innerMin[ d ] )
+							innerMin[ d ] = nodei.max( d ) + 1;
+						if ( nodei.min( d ) - 1 > innerMax[ d ] )
+							innerMax[ d ] = nodei.min( d ) - 1;
+					}
+				}
+				else if ( node.hasBitMask() )
+				{
+					node.bitmask().computeBoundingBox( leafbbmin, leafbbmax, leafbbtmp );
+					for ( int d = 0; d < n; ++d )
+					{
+						final long dmin = nodei.min( d ) + leafbbmin[ d ];
+						final long dmax = nodei.min( d ) + leafbbmax[ d ];
+						if ( dmin < outerMin[ d ] )
+							outerMin[ d ] = dmin;
+						if ( dmax > outerMax[ d ] )
+							outerMax[ d ] = dmax;
+						if ( dmin < innerMin[ d ] )
+							innerMin[ d ] = dmin;
+						if ( dmax > innerMax[ d ] )
+							innerMax[ d ] = dmax;
+					}
+				}
+				else if ( node.value() )
+				{
+					for ( int d = 0; d < n; ++d )
+					{
+						if ( nodei.min( d ) < outerMin[ d ] )
+							outerMin[ d ] = nodei.min( d );
+						if ( nodei.max( d ) > outerMax[ d ] )
+							outerMax[ d ] = nodei.max( d );
+						if ( nodei.min( d ) < innerMin[ d ] )
+							innerMin[ d ] = nodei.min( d );
+						if ( nodei.max( d ) > innerMax[ d ] )
+							innerMax[ d ] = nodei.max( d );
+					}
+				}
+
+				// we just visited a node at level l, do not recurse further
+				return false;
+			} );
+
+			// everything outside the outer bbox can be truncated in next iteration
+			System.arraycopy( outerMin, 0, truncMin, 0, n );
+			System.arraycopy( outerMax, 0, truncMax, 0, n );
+		}
+
+		return new FinalInterval( outerMin, outerMax );
+	}
+}

--- a/src/main/java/net/imglib2/roi/sparse/SparseBitmaskNTree.java
+++ b/src/main/java/net/imglib2/roi/sparse/SparseBitmaskNTree.java
@@ -200,7 +200,7 @@ public interface SparseBitmaskNTree extends EuclideanSpace, Iterable< Node >
 	 * @param tree a {@code SparseBitmaskNTree}
 	 * @return the bounding box of {@code true} pixels in a {@code tree}.
 	 */
-	static Interval bbox( final SparseBitmaskNTree tree )
+	static Interval boundingBox( final SparseBitmaskNTree tree )
 	{
 		final int n = tree.numDimensions();
 

--- a/src/main/java/net/imglib2/roi/sparse/Tree.java
+++ b/src/main/java/net/imglib2/roi/sparse/Tree.java
@@ -330,6 +330,7 @@ public class Tree implements SparseBitmaskNTree
 
 		int nextChildindex;
 
+		// TODO: the should be and Intervals.wrap( min, max ) method that does this
 		private final Interval interval = new DefaultInterval()
 		{
 			@Override

--- a/src/main/java/net/imglib2/roi/sparse/Tree.java
+++ b/src/main/java/net/imglib2/roi/sparse/Tree.java
@@ -161,21 +161,26 @@ public class Tree implements SparseBitmaskNTree
 	private NodeData getNode( final long[] pos, final int maxDepth )
 	{
 		NodeData current = root;
-		for ( int l = height - 1; l >= maxDepth; --l )
+		for ( int level = height - 1; level >= maxDepth; --level )
 		{
 			if ( !current.hasChildren() )
 				break;
 
-			int childindex = 0;
-			for ( int d = 0; d < n; ++d )
-			{
-				final long bitmask = ( ( long ) leafDims[ d ] ) << l;
-				if ( ( pos[ d ] & bitmask ) != 0 )
-					childindex |= 1 << d;
-			}
-			current = current.children[ childindex ];
+			current = current.children[ getChildIndex( pos, level ) ];
 		}
 		return current;
+	}
+
+	private int getChildIndex( long[] pos, int level )
+	{
+		int childindex = 0;
+		for ( int d = 0; d < n; ++d )
+		{
+			final long bitmask = ( ( long ) leafDims[ d ] ) << level;
+			if ( ( pos[ d ] & bitmask ) != 0 )
+				childindex |= 1 << d;
+		}
+		return childindex;
 	}
 
 	@Override
@@ -225,14 +230,7 @@ public class Tree implements SparseBitmaskNTree
 					current.children[ i ] = new NodeData( current, current.value );
 			}
 
-			int childindex = 0;
-			for ( int d = 0; d < n; ++d )
-			{
-				final long bitmask = ( ( long ) leafDims[ d ] ) << l;
-				if ( ( pos[ d ] & bitmask ) != 0 )
-					childindex |= 1 << d;
-			}
-			current = current.children[ childindex ];
+			current = current.children[ getChildIndex( pos, l ) ];
 		}
 
 		if ( current.data == null && current.value != value )

--- a/src/main/java/net/imglib2/roi/sparse/Tree.java
+++ b/src/main/java/net/imglib2/roi/sparse/Tree.java
@@ -1,0 +1,734 @@
+package net.imglib2.roi.sparse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import net.imglib2.Interval;
+import net.imglib2.roi.sparse.util.BitUtils;
+import net.imglib2.roi.sparse.util.DefaultInterval;
+import net.imglib2.util.Intervals;
+
+/*
+ * The level of a nodeData corresponds to its height in a fully populated tree.
+ * I.e, the level of a nodeData is height of the fully populated tree minus the depth of the nodeData.
+ */
+
+/**
+ * A {@link SparseBitmaskNTree} with fixed dimensions. (Dimensions are specified
+ * by height of the tree and dimensions of the leaf bitmasks.)
+ * <p>
+ * This class is not thread-safe!
+ *
+ * @author Tobias Pietzsch
+ */
+public class Tree implements SparseBitmaskNTree
+{
+	/**
+	 * Number of dimensions.
+	 */
+	private final int n;
+
+	/**
+	 * How many children a inner node has ({@code 2^n}).
+	 */
+	private final int numChildren;
+
+	/**
+	 * Dimensions of a leaf bit-mask. <em>Every element must be a power of
+	 * 2!</em>
+	 */
+	private final int[] leafDims;
+
+	/**
+	 * Mask out tile coordinate part from a position. Because leafDims are power
+	 * of 2, {@code leafMask[ d ] = leafDims[ d ] - 1}
+	 */
+	private final int[] leafMask;
+
+	/**
+	 * Number of bits in a leaf bit-mask.
+	 */
+	private final int leafBitSize;
+
+	/**
+	 * Dimensions of a leaf bit-mask in bytes. This is the same as leafDims (the
+	 * dimensions of the bitmask), except that leafDims[0] is divided by 8.
+	 */
+	private final int[] leafByteDims;
+
+	/**
+	 * The current height of the tree.
+	 */
+	private int height;
+
+	/**
+	 * The current root node.
+	 */
+	private NodeData root;
+
+	/**
+	 * Max of interval covered by current root node.
+	 */
+	private final long[] currentBoundsMax;
+
+	/**
+	 * @param leafDims
+	 *            Dimensions of a leaf bit-mask. <em>Every element must be a
+	 *            power of 2!</em>
+	 * @param height
+	 *            Initial height of the tree.
+	 */
+	public Tree(
+			final int[] leafDims,
+			final int height )
+	{
+		checkLeafDims( leafDims );
+
+		n = leafDims.length;
+		this.leafDims = leafDims.clone();
+
+		leafMask = new int[ n ];
+		Arrays.setAll( leafMask, d -> leafDims[ d ] - 1 );
+
+		final long lsize = Intervals.numElements( leafDims );
+		if ( lsize > Integer.MAX_VALUE )
+			throw new IllegalArgumentException();
+		leafBitSize = ( int ) lsize;
+
+		leafByteDims = leafDims.clone();
+		leafByteDims[ 0 ] = leafByteDims[ 0 ] >> 3;
+
+		this.height = height;
+		numChildren = 1 << n;
+
+		root = new NodeData( null, false );
+
+		currentBoundsMax = new long[ n ];
+		updateCurrentBoundsMax();
+	}
+
+	/**
+	 * Check dimensions of leaf bit-mask (for constructor).
+	 * Verify that
+	 * <ul>
+	 *     <li>{@code leafDims} has at least one element,</li>
+	 *     <li>every element is a (non-zero) power of two, and</li>
+	 *     <li>{@code leafDims[0]} is at least 8.</li>
+	 * </ul>
+	 */
+	private static void checkLeafDims( final int[] leafDims )
+	{
+		if ( leafDims == null || leafDims.length == 0 )
+			throw new IllegalArgumentException( "leafDims must not be empty");
+
+		for ( int i = 0; i < leafDims.length; i++ )
+		{
+			final int leafDim = leafDims[ i ];
+			if ( leafDim < 1 )
+				throw new IllegalArgumentException( "leafDim[ " + i + "] must be >= 1");
+			if ( i == 0 && leafDim < 8 )
+				throw new IllegalArgumentException( "leafDim[0] must be >= 8");
+			if ( Integer.highestOneBit( leafDim ) != leafDim )
+				throw new IllegalArgumentException( "leafDim[ " + i + "] must be a power of 2");
+		}
+	}
+
+	@Override
+	public int height()
+	{
+		return height;
+	}
+
+	@Override
+	public int numDimensions()
+	{
+		return n;
+	}
+
+	private static class NodeData
+	{
+		boolean value;
+
+		BitMask data;
+
+		NodeData parent;
+
+		NodeData[] children;
+
+		NodeData( final NodeData parent, final boolean value )
+		{
+			this.parent = parent;
+			this.value = value;
+		}
+
+		boolean hasChildren()
+		{
+			return children != null;
+		}
+	}
+
+	/**
+	 * Get the lowest-level node containing position. Note that position is not
+	 * necessarily the only pixel inside the node.
+	 * <p>
+	 * The level of a node corresponds to its height in a fully populated tree.
+	 * I.e., the level of a node is the depth of the fully populated tree minus
+	 * the depth of the node. For example, leaf nodes in the fully populated
+	 * tree have level {@code 0}.
+	 *
+	 * @param pos
+	 *            a position inside the image.
+	 * @param maxDepth
+	 *            maximum depth of the requested node. {@code maxDepth > 0}
+	 *            means that the search is possibly terminated early.
+	 *
+	 * @return the lowest-level node containing position.
+	 */
+	private NodeData getNode( final long[] pos, final int maxDepth )
+	{
+		NodeData current = root;
+		for ( int l = height - 1; l >= maxDepth; --l )
+		{
+			if ( !current.hasChildren() )
+				break;
+
+			int childindex = 0;
+			for ( int d = 0; d < n; ++d )
+			{
+				final long bitmask = ( ( long ) leafDims[ d ] ) << l;
+				if ( ( pos[ d ] & bitmask ) != 0 )
+					childindex |= 1 << d;
+			}
+			current = current.children[ childindex ];
+		}
+		return current;
+	}
+
+	@Override
+	public boolean get( final long[] pos )
+	{
+		final NodeData node = getNode( pos, 0 );
+
+		if ( node.data == null )
+			return node.value;
+
+		return node.data.get( pos );
+	}
+
+	/**
+	 * For debugging.
+	 *
+	 * returns 0 if false
+	 * returns 1 if true
+	 * returns 2 if mixed
+	 */
+	public int get( final long[] pos, final int level )
+	{
+		final NodeData node = getNode( pos, level );
+
+		if ( node.hasChildren() )
+			return 2;
+
+		if ( node.data == null )
+			return node.value ? 1 : 0;
+
+		return node.data.get( pos ) ? 1 : 0;
+	}
+
+	@Override
+	public void set( final long[] pos, final boolean value )
+	{
+		NodeData current = root;
+		for ( int l = height - 1; l >= 0; --l )
+		{
+			if ( !current.hasChildren() )
+			{
+				if ( current.value == value )
+					return;
+
+				current.children = new NodeData[ numChildren ];
+				for ( int i = 0; i < numChildren; ++i )
+					current.children[ i ] = new NodeData( current, current.value );
+			}
+
+			int childindex = 0;
+			for ( int d = 0; d < n; ++d )
+			{
+				final long bitmask = ( ( long ) leafDims[ d ] ) << l;
+				if ( ( pos[ d ] & bitmask ) != 0 )
+					childindex |= 1 << d;
+			}
+			current = current.children[ childindex ];
+		}
+
+		if ( current.data == null && current.value != value )
+			current.data = new BitMask( current.value );
+
+		if ( current.data != null && current.data.set( pos, value ) )
+		{
+			current.data = null;
+			current.value = value;
+			mergeUpwards( current, value );
+		}
+	}
+
+	/**
+	 * Create a new root, and push current root one level down. The new
+	 * root will have the current root as a child at index {@code childindex}.
+	 * All other children of the new root are leaf nodes with value
+	 * {@code false}.
+	 */
+	void grow( final int childindex )
+	{
+		++height;
+		final NodeData oldroot = root;
+
+		root = new NodeData( null, false );
+		root.children = new NodeData[ numChildren ];
+		for ( int i = 0; i < numChildren; ++i )
+			root.children[ i ] = ( i == childindex )
+					? oldroot
+					: new NodeData( root, false );
+		oldroot.parent = root;
+		if ( !oldroot.hasChildren() && oldroot.data == null )
+			mergeUpwards( oldroot, oldroot.value );
+
+		updateCurrentBoundsMax();
+	}
+
+
+	/**
+	 * If all the children of our parent have the same value remove them all.
+	 * Call recursively for parent.
+	 *
+	 * @param node
+	 *            the starting node (whose parents should be tested
+	 *            recursively).
+	 * @return nodeData that the starting nodeData was ultimately merged into.
+	 */
+	private void mergeUpwards( final NodeData node, final boolean value )
+	{
+		final NodeData parent = node.parent;
+		if ( parent == null )
+			return;
+		for ( int i = 0; i < numChildren; ++i )
+		{
+			final NodeData child = parent.children[ i ];
+			if ( child.hasChildren() || child.data != null || child.value != value )
+				return;
+		}
+		parent.value = value;
+		parent.children = null;
+		mergeUpwards( parent, value );
+	}
+
+	/**
+	 * Bit-mask are stored in the leafs of the tree. Each bit-mask is a
+	 * {@code leafDims}-sized boolean image backed by a {@code byte[]} array. It
+	 * also keeps track of how many bits are currently set.
+	 */
+	class BitMask
+	{
+		/**
+		 * Stores data of this mask
+		 */
+		private final byte[] bytes;
+
+		/**
+		 * Current number of true bits in this mask
+		 */
+		private int numSet;
+
+		/**
+		 * Create a new BitMask that is initially completely filled with the
+		 * given value.
+		 *
+		 * @param initialValue
+		 */
+		BitMask( final boolean initialValue )
+		{
+			bytes = new byte[ leafBitSize >> 3 ];
+			if ( initialValue )
+			{
+				Arrays.fill( bytes, ( byte ) 255 );
+				numSet = leafBitSize;
+			}
+			else
+			{
+				numSet = 0;
+			}
+		}
+
+		/**
+		 * @param globalpos
+		 *            global position of the bit to set
+		 * @param value
+		 *            value to set the bit to
+		 * @return {@code true} iff the mask was completely filled or emptied by
+		 *         this operation
+		 */
+		boolean set( final long[] globalpos, final boolean value )
+		{
+			final int i = byteIndex( globalpos );
+			final int mask = 1 << ( globalpos[ 0 ] & leafMask[ 0 ] & 0x07 );
+
+			final byte b = bytes[ i ];
+			if ( value )
+			{
+				final byte bm = ( byte ) ( b | mask );
+				if ( bm != b ) // changing bit from 0 to 1
+				{
+					bytes[ i ] = bm;
+					if ( ++numSet == leafBitSize )
+						return true;
+				}
+			}
+			else
+			{
+				final byte bm = ( byte ) ( b & ~mask );
+				if ( bm != b ) // changing bit from 1 to 0
+				{
+					bytes[ i ] = bm;
+					if ( --numSet == 0 )
+						return true;
+				}
+			}
+
+			return false;
+		}
+
+		boolean get( final long[] globalpos )
+		{
+			final byte b = bytes[ byteIndex( globalpos ) ];
+			final int mask = 1 << ( globalpos[ 0 ] & leafMask[ 0 ] & 0x07 );
+			return ( b & mask ) != 0;
+		}
+
+		private int byteIndex( final long[] globalpos )
+		{
+			int i = 0;
+			for ( int d = n - 1; d > 0; --d )
+				i = ( i + ( int ) ( globalpos[ d ] & leafMask[ d ] ) ) * leafByteDims[ d - 1 ];
+			return i + ( ( ( int ) ( globalpos[ 0 ] & leafMask[ 0 ] ) ) >> 3 );
+		}
+
+		int numSet()
+		{
+			return numSet;
+		}
+
+		/**
+		 * Recompute the bounding box of true mask pixels. The result is stored
+		 * in {@code bbmin}, {@code bbmax}
+		 *
+		 * @param bbmin
+		 *            bounding box min is stored here
+		 * @param bbmax
+		 *            bounding box min is stored here
+		 * @param tmp
+		 *            temporary variable for storing positions while scanning
+		 *            the mask.
+		 */
+		void computeBoundingBox( final int[] bbmin, final int[] bbmax, final int[] tmp )
+		{
+			Arrays.fill( bbmin, Integer.MAX_VALUE );
+			Arrays.fill( bbmax, Integer.MIN_VALUE );
+			if ( numSet == 0 )
+				return;
+
+			Arrays.fill( tmp, 0 );
+			for ( int i = 0; i < bytes.length; ++i )
+			{
+				if ( bytes[ i ] != 0 )
+				{
+					for ( int d = 0; d < n; ++d )
+					{
+						bbmin[ d ] = Math.min( bbmin[ d ], tmp[ d ] );
+						bbmax[ d ] = Math.max( bbmax[ d ], tmp[ d ] );
+					}
+				}
+				for ( int d = 0; d < n; ++d )
+				{
+					if ( ++tmp[ d ] == leafByteDims[ d ] )
+						tmp[ d ] = 0;
+					else
+						break;
+				}
+			}
+
+			final int step = leafByteDims[ 0 ];
+
+			byte minproj = 0;
+			for ( int i = bbmin[ 0 ]; i < bytes.length; i += step )
+				minproj |= bytes[ i ];
+
+			byte maxproj = 0;
+			if ( bbmin[ 0 ] == bbmax[ 0 ] )
+				maxproj = minproj;
+			else
+				for ( int i = bbmax[ 0 ]; i < bytes.length; i += step )
+					maxproj |= bytes[ i ];
+
+			bbmin[ 0 ] = ( bbmin[ 0 ] << 3 ) + BitUtils.lowestOneBit( minproj );
+			bbmax[ 0 ] = ( bbmax[ 0 ] << 3 ) + BitUtils.highestOneBit( maxproj );
+		}
+	}
+
+	@Override
+	public void forEach( final Predicate< Node > op )
+	{
+		final NodeIteratorImp iter = new NodeIteratorImp();
+		while ( iter.hasNext() )
+			if ( !op.test( iter.next() ) )
+				iter.truncate();
+	}
+
+	@Override
+	public NodeIterator iterator()
+	{
+		return new NodeIteratorImp();
+	}
+
+	/**
+	 * A stack of these is used to implement NodeIterator.
+	 */
+	private static class NodeImp implements Node
+	{
+		private final int n;
+
+		final int level;
+
+		NodeData nodeData;
+
+		final long[] min;
+
+		final long[] max;
+
+		int nextChildindex;
+
+		private final Interval interval = new DefaultInterval()
+		{
+			@Override
+			public long min( final int d )
+			{
+				return min[ d ];
+			}
+
+			@Override
+			public long max( final int d )
+			{
+				return max[ d ];
+			}
+
+			@Override
+			public long dimension( final int d )
+			{
+				return max[ d ] - min[ d ] + 1;
+			}
+
+			@Override
+			public int numDimensions()
+			{
+				return n;
+			}
+		};
+
+		NodeImp( final int level, final int numDimensions )
+		{
+			this.level = level;
+			n = numDimensions;
+			min = new long[ n ];
+			max = new long[ n ];
+		}
+
+		@Override
+		public boolean hasChildren()
+		{
+			return nodeData.children != null;
+		}
+
+		@Override
+		public boolean value()
+		{
+			return nodeData.value;
+		}
+
+		@Override
+		public BitMask bitmask()
+		{
+			return nodeData.data;
+		}
+
+		@Override
+		public Interval interval()
+		{
+			return interval;
+		}
+
+		@Override
+		public int level()
+		{
+			return level;
+		}
+	}
+
+	private class NodeIteratorImp implements NodeIterator
+	{
+		private final ArrayList< NodeImp > nds;
+
+		private NodeImp next;
+
+		private NodeImp current;
+
+		NodeIteratorImp()
+		{
+			nds = new ArrayList<>( height + 1 );
+			for ( int h = 0; h <= height; ++h )
+				nds.add( new NodeImp( h, n ) );
+			reset();
+		}
+
+		private NodeIteratorImp( final NodeIteratorImp other )
+		{
+			nds = new ArrayList<>( height + 1 );
+			for ( int h = 0; h <= height; ++h )
+			{
+				final NodeImp nd = new NodeImp( h, n );
+				final NodeImp ndo = other.nds.get( h );
+				nd.nodeData = ndo.nodeData;
+				System.arraycopy( ndo.min, 0, nd.min, 0, n );
+				System.arraycopy( ndo.max, 0, nd.max, 0, n );
+				nd.nextChildindex = ndo.nextChildindex;
+
+				nds.add( nd );
+
+				if ( other.current == ndo )
+					current = nd;
+				if ( other.next == ndo )
+					next = nd;
+			}
+		}
+
+		@Override
+		public void reset()
+		{
+			final NodeImp rootData = nds.get( height );
+			for ( int d = 0; d < n; ++d )
+			{
+				rootData.min[ d ] = 0;
+				final long s = ( ( long ) leafDims[ d ] ) << height;
+				rootData.max[ d ] = rootData.min[ d ] + s - 1;
+			}
+			rootData.nodeData = root;
+			rootData.nextChildindex = root.hasChildren() ? 0 : numChildren;
+			next = rootData;
+			current = null;
+		}
+
+		@Override
+		public NodeIterator copy()
+		{
+			return new NodeIteratorImp( this );
+		}
+
+		@Override
+		public boolean hasNext()
+		{
+			return next != null;
+		}
+
+		@Override
+		public Node next()
+		{
+			current = next;
+			final int l = current.level;
+			if ( l < height )
+			{
+				final NodeImp parentData = nds.get( l + 1 );
+				final int i = parentData.nextChildindex++;
+				current.nodeData = parentData.nodeData.children[ i ];
+				current.nextChildindex = current.hasChildren() ? 0 : numChildren;
+				for ( int d = 0; d < n; ++d )
+				{
+					final long s = ( ( long ) leafDims[ d ] ) << l;
+					final long min = parentData.min[ d ] + (
+							( i & ( 1 << d ) ) == 0
+									? 0
+									: s );
+					current.min[ d ] = min;
+					current.max[ d ] = min + s - 1;
+				}
+			}
+			next = getNext( current );
+			return current;
+		}
+
+		@Override
+		public Node current()
+		{
+			return current;
+		}
+
+		void truncate()
+		{
+			current.nextChildindex = numChildren;
+			next = getNext( current );
+		}
+
+		private NodeImp getNext( NodeImp nodeData )
+		{
+			while ( nodeData.nextChildindex >= numChildren )
+			{
+				final int l = nodeData.level;
+				if ( l == height )
+				{
+					return null;
+				}
+				nodeData = nds.get( l + 1 );
+			}
+			return nds.get( nodeData.level - 1 );
+		}
+	}
+
+	private void updateCurrentBoundsMax()
+	{
+		for ( int d = 0; d < n; ++d )
+			currentBoundsMax[ d ] = ( leafDims[ d ] << height ) - 1;
+	}
+
+	/**
+	 * The current interval covered by the tree (resp. the root node).
+	 */
+	private final Interval currentBounds = new DefaultInterval()
+	{
+		@Override
+		public int numDimensions()
+		{
+			return n;
+		}
+
+		@Override
+		public long dimension( final int d )
+		{
+			return currentBoundsMax[ d ] + 1;
+		}
+
+		@Override
+		public long min( final int d )
+		{
+			return 0;
+		}
+
+		@Override
+		public long max( final int d )
+		{
+			return currentBoundsMax[ d ];
+		}
+	};
+
+	Interval bounds()
+	{
+		return currentBounds;
+	}
+}

--- a/src/main/java/net/imglib2/roi/sparse/Tree.java
+++ b/src/main/java/net/imglib2/roi/sparse/Tree.java
@@ -1,12 +1,10 @@
 package net.imglib2.roi.sparse;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.function.Predicate;
 
 import net.imglib2.Interval;
 import net.imglib2.roi.sparse.util.DefaultInterval;
-import net.imglib2.util.Intervals;
 
 /*
  * The level of a nodeData corresponds to its height in a fully populated tree.
@@ -39,7 +37,7 @@ public class Tree implements SparseBitmaskNTree
 	 */
 	private final int[] leafDims;
 
-	private final BitMask.Specification bitmaskSpecification;
+	private final LeafBitmask.Specification bitmaskSpecification;
 
 	/**
 	 * The current height of the tree.
@@ -72,7 +70,7 @@ public class Tree implements SparseBitmaskNTree
 		this.leafDims = leafDims.clone();
 		n = leafDims.length;
 
-		bitmaskSpecification = new BitMask.Specification( this.leafDims );
+		bitmaskSpecification = new LeafBitmask.Specification( this.leafDims );
 
 		this.height = height;
 		numChildren = 1 << n;
@@ -125,7 +123,7 @@ public class Tree implements SparseBitmaskNTree
 	{
 		boolean value;
 
-		BitMask data;
+		LeafBitmask data;
 
 		NodeData parent;
 
@@ -238,7 +236,7 @@ public class Tree implements SparseBitmaskNTree
 		}
 
 		if ( current.data == null && current.value != value )
-			current.data = new BitMask( bitmaskSpecification, current.value );
+			current.data = new LeafBitmask( bitmaskSpecification, current.value );
 
 		if ( current.data != null && current.data.set( pos, value ) )
 		{
@@ -379,7 +377,7 @@ public class Tree implements SparseBitmaskNTree
 		}
 
 		@Override
-		public BitMask bitmask()
+		public LeafBitmask bitmask()
 		{
 			return nodeData.data;
 		}

--- a/src/main/java/net/imglib2/roi/sparse/Tree.java
+++ b/src/main/java/net/imglib2/roi/sparse/Tree.java
@@ -141,10 +141,10 @@ public class Tree implements SparseBitmaskNTree
 		NodeData current = root;
 		for ( int level = height - 1; level >= maxDepth; --level )
 		{
-			if ( !current.hasChildren() )
-				break;
-
-			current = current.child( getChildIndex( pos, level ) );
+			final NodeData child = current.child( getChildIndex( pos, level ) );
+			if( child == null )
+				return current;
+			current = child;
 		}
 		return current;
 	}
@@ -166,10 +166,11 @@ public class Tree implements SparseBitmaskNTree
 	{
 		final NodeData node = getNode( pos, 0 );
 
-		if ( node.bitmask() == null )
+		final LeafBitmask bitmask = node.bitmask();
+		if ( bitmask == null )
 			return node.value();
 
-		return node.bitmask().get( pos );
+		return bitmask.get( pos );
 	}
 
 	/**
@@ -233,6 +234,7 @@ public class Tree implements SparseBitmaskNTree
 		if ( !oldroot.hasChildren() && oldroot.bitmask() == null )
 			mergeUpwards( oldroot, oldroot.value() );
 		updateCurrentBoundsMax();
+		throw new RuntimeException( "Changing height and root separately breaks get and set." );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/roi/sparse/Tree.java
+++ b/src/main/java/net/imglib2/roi/sparse/Tree.java
@@ -198,7 +198,7 @@ public class Tree implements SparseBitmaskNTree
 	 * returns 1 if true
 	 * returns 2 if mixed
 	 */
-	public int get( final long[] pos, final int level )
+	public int getForDebugging( final long[] pos, final int level )
 	{
 		final NodeData node = getNode( pos, level );
 

--- a/src/main/java/net/imglib2/roi/sparse/Tree.java
+++ b/src/main/java/net/imglib2/roi/sparse/Tree.java
@@ -166,10 +166,10 @@ public class Tree implements SparseBitmaskNTree
 	{
 		final NodeData node = getNode( pos, 0 );
 
-		if ( node.data() == null )
+		if ( node.bitmask() == null )
 			return node.value();
 
-		return node.data().get( pos );
+		return node.bitmask().get( pos );
 	}
 
 	/**
@@ -186,10 +186,10 @@ public class Tree implements SparseBitmaskNTree
 		if ( node.hasChildren() )
 			return 2;
 
-		if ( node.data() == null )
+		if ( node.bitmask() == null )
 			return node.value() ? 1 : 0;
 
-		return node.data().get( pos ) ? 1 : 0;
+		return node.bitmask().get( pos ) ? 1 : 0;
 	}
 
 	@Override
@@ -209,10 +209,10 @@ public class Tree implements SparseBitmaskNTree
 			current = current.child( getChildIndex( pos, l ) );
 		}
 
-		if ( current.data() == null && current.value() != value )
+		if ( current.bitmask() == null && current.value() != value )
 			current.createBitmask( bitmaskSpecification );
 
-		if ( current.data() != null && current.data().set( pos, value ) )
+		if ( current.bitmask() != null && current.bitmask().set( pos, value ) )
 		{
 			current.mergeLeafToValue( value );
 			mergeUpwards( current, value );
@@ -230,7 +230,7 @@ public class Tree implements SparseBitmaskNTree
 		++height;
 		final NodeData oldroot = root;
 		root = oldroot.newParent( childindex, numChildren );
-		if ( !oldroot.hasChildren() && oldroot.data() == null )
+		if ( !oldroot.hasChildren() && oldroot.bitmask() == null )
 			mergeUpwards( oldroot, oldroot.value() );
 		updateCurrentBoundsMax();
 	}
@@ -337,7 +337,7 @@ public class Tree implements SparseBitmaskNTree
 		@Override
 		public LeafBitmask bitmask()
 		{
-			return nodeData.data();
+			return nodeData.bitmask();
 		}
 
 		@Override

--- a/src/main/java/net/imglib2/roi/sparse/util/BitUtils.java
+++ b/src/main/java/net/imglib2/roi/sparse/util/BitUtils.java
@@ -1,0 +1,66 @@
+package net.imglib2.roi.sparse.util;
+
+/**
+ * @author Tobias Pietzsch
+ */
+public class BitUtils
+{
+	/**
+	 * Find the highest 1-bit in byte {@code b}.
+	 *
+	 * @return the index of the highest 1-bit {@code b}, or {@code -1} if no bit is set.
+	 */
+	public static int highestOneBit( byte b )
+	{
+		if ( b == 0 )
+			return -1;
+
+		int highest = 0;
+		if ( ( b & 0xf0 ) != 0 )
+		{
+			highest += 4;
+			b >>>= 4;
+		}
+		if ( ( b & 0x0c ) != 0 )
+		{
+			highest += 2;
+			b >>>= 2;
+		}
+		if ( ( b & 0x2 ) != 0 )
+		{
+			highest += 1;
+		}
+
+		return highest;
+	}
+
+	/**
+	 * Find the lowest 1-bit in byte {@code b}.
+	 *
+	 * @return the index of the lowest 1-bit {@code b}, or {@code -1} if no bit is set.
+	 */
+	public static int lowestOneBit( byte b )
+	{
+		if ( b == 0 )
+			return -1;
+
+		int lowest = 0;
+		if ( ( b & 0x0f ) == 0 )
+		{
+			lowest += 4;
+			b >>>= 4;
+		}
+		if ( ( b & 0x03 ) == 0 )
+		{
+			lowest += 2;
+			b >>>= 2;
+		}
+		if ( ( b & 0x01 ) == 0 )
+		{
+			lowest += 1;
+		}
+
+		return lowest;
+	}
+
+}

--- a/src/main/java/net/imglib2/roi/sparse/util/DefaultInterval.java
+++ b/src/main/java/net/imglib2/roi/sparse/util/DefaultInterval.java
@@ -7,6 +7,7 @@ import net.imglib2.RealPositionable;
 /**
  * @author Tobias Pietzsch
  */
+// FIXME: move all the default implementations to the Interval class
 public interface DefaultInterval extends Interval
 {
 	@Override
@@ -20,7 +21,7 @@ public interface DefaultInterval extends Interval
 	{
 		final int n = numDimensions();
 		for ( int d = 0; d < n; d++ )
-			min[ d ] = min( d );
+			min[ d ] = realMin( d );
 	}
 
 	@Override
@@ -28,7 +29,7 @@ public interface DefaultInterval extends Interval
 	{
 		final int n = numDimensions();
 		for ( int d = 0; d < n; d++ )
-			min.setPosition( min( d ), d );
+			min.setPosition( realMin( d ), d );
 	}
 
 	@Override
@@ -42,7 +43,7 @@ public interface DefaultInterval extends Interval
 	{
 		final int n = numDimensions();
 		for ( int d = 0; d < n; d++ )
-			max[ d ] = max( d );
+			max[ d ] = realMax( d );
 	}
 
 	@Override
@@ -50,7 +51,7 @@ public interface DefaultInterval extends Interval
 	{
 		final int n = numDimensions();
 		for ( int d = 0; d < n; d++ )
-			max.setPosition( max( d ), d );
+			max.setPosition( realMax( d ), d );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/roi/sparse/util/DefaultInterval.java
+++ b/src/main/java/net/imglib2/roi/sparse/util/DefaultInterval.java
@@ -1,0 +1,95 @@
+package net.imglib2.roi.sparse.util;
+
+import net.imglib2.Interval;
+import net.imglib2.Positionable;
+import net.imglib2.RealPositionable;
+
+/**
+ * @author Tobias Pietzsch
+ */
+public interface DefaultInterval extends Interval
+{
+	@Override
+	default double realMin( final int d )
+	{
+		return min( d );
+	}
+
+	@Override
+	default void realMin( final double[] min )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			min[ d ] = min( d );
+	}
+
+	@Override
+	default void realMin( final RealPositionable min )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			min.setPosition( min( d ), d );
+	}
+
+	@Override
+	default double realMax( final int d )
+	{
+		return max( d );
+	}
+
+	@Override
+	default void realMax( final double[] max )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			max[ d ] = max( d );
+	}
+
+	@Override
+	default void realMax( final RealPositionable max )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			max.setPosition( max( d ), d );
+	}
+
+	@Override
+	default void dimensions( final long[] dimensions )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			dimensions[ d ] = dimension( d );
+	}
+
+	@Override
+	default void min( final long[] min )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			min[ d ] = min( d );
+	}
+
+	@Override
+	default void min( final Positionable min )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			min.setPosition( min( d ), d );
+	}
+
+	@Override
+	default void max( final long[] max )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			max[ d ] = max( d );
+	}
+
+	@Override
+	default void max( final Positionable max )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			max.setPosition( max( d ), d );
+	}
+}

--- a/src/test/java/net/imglib2/roi/sparse/GrowableTreeTest.java
+++ b/src/test/java/net/imglib2/roi/sparse/GrowableTreeTest.java
@@ -1,0 +1,14 @@
+package net.imglib2.roi.sparse;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GrowableTreeTest
+{
+	@Test
+	public void testCreate() {
+		GrowableTree tree = new GrowableTree( new int[] { 8, 8, 8 } );
+		assertEquals(0,  tree.height());
+	}
+}

--- a/src/test/java/net/imglib2/roi/sparse/SparseBitmaskBenchmark.java
+++ b/src/test/java/net/imglib2/roi/sparse/SparseBitmaskBenchmark.java
@@ -1,0 +1,54 @@
+package net.imglib2.roi.sparse;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.neighborhood.HyperSphereShape;
+import net.imglib2.algorithm.neighborhood.Neighborhood;
+import net.imglib2.img.sparse.NtreeImg;
+import net.imglib2.img.sparse.NtreeImgFactory;
+import net.imglib2.type.BooleanType;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+public class SparseBitmaskBenchmark
+{
+	@Benchmark
+	public void benchmark() {
+		SparseBitmask bitmask = new SparseBitmask( 2 );
+		fillHypersphere( bitmask, 50, 50, 50 );
+	}
+
+	@Benchmark
+	public void benchmarkNDTree() {
+		NtreeImg< UnsignedByteType, ? > image = new NtreeImgFactory<>( new UnsignedByteType() ).create( 100, 100 );
+		fillHypersphere( image, 50, 50, 50 );
+	}
+
+	public static void main( final String... args ) throws RunnerException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( SparseBitmaskBenchmark.class.getSimpleName() )
+				.forks( 0 )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 100 ) )
+				.measurementTime( TimeValue.milliseconds( 100 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+
+	private static void fillHypersphere( RandomAccessible< ? extends NumericType<?> > img, long radius, long... position )
+	{
+		RandomAccess< ? extends Neighborhood< ? extends NumericType< ? > > > a = new HyperSphereShape( radius ).neighborhoodsRandomAccessible( img ).randomAccess();
+		a.setPosition( position );
+		a.get().forEach( t -> t.setOne() );
+	}
+}

--- a/src/test/java/net/imglib2/roi/sparse/SparseBitmaskBenchmark.java
+++ b/src/test/java/net/imglib2/roi/sparse/SparseBitmaskBenchmark.java
@@ -8,15 +8,28 @@ import net.imglib2.algorithm.neighborhood.Neighborhood;
 import net.imglib2.img.sparse.NtreeImg;
 import net.imglib2.img.sparse.NtreeImgFactory;
 import net.imglib2.roi.sparse.labkit.SparseIterableRegion;
+import net.imglib2.type.logic.NativeBoolType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.view.Views;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@State( Scope.Benchmark )
 public class SparseBitmaskBenchmark
 {
 	@Benchmark
@@ -35,6 +48,35 @@ public class SparseBitmaskBenchmark
 	public void labkitSparse() {
 		SparseIterableRegion image = new SparseIterableRegion( new FinalInterval( 100, 100, 100 ) );
 		fillHypersphere( image, 50, 50, 50, 50 );
+	}
+
+	SparseBitmask sphere = initSphere();
+
+	private SparseBitmask initSphere()
+	{
+		SparseBitmask image = new SparseBitmask( 3 );
+		fillHypersphere( image, 50, 50, 50, 50 );
+		return image;
+	}
+
+	@Benchmark
+	public void read(Blackhole bh) throws InterruptedException
+	{
+		Runnable action = () -> {
+			long sum = 0;
+			for(NativeBoolType pixel : Views.interval(sphere, new FinalInterval( 100, 100, 100 ) ))
+				if(pixel.get()) sum++;
+			bh.consume( sum );
+		};
+		executeInParallel( action, 8 );
+	}
+
+	private void executeInParallel( Runnable action, int numberOfThreads ) throws InterruptedException
+	{
+		ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+		List<Callable<Void>> tasks = IntStream.range( 0, numberOfThreads ).mapToObj( ignore -> (Callable<Void>) () -> { action.run(); return null; } ).collect( Collectors.toList() );
+		executorService.invokeAll( tasks );
+		executorService.shutdown();
 	}
 
 	public static void main( final String... args ) throws RunnerException

--- a/src/test/java/net/imglib2/roi/sparse/SparseBitmaskBenchmark.java
+++ b/src/test/java/net/imglib2/roi/sparse/SparseBitmaskBenchmark.java
@@ -1,14 +1,13 @@
 package net.imglib2.roi.sparse;
 
+import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.algorithm.neighborhood.HyperSphereShape;
 import net.imglib2.algorithm.neighborhood.Neighborhood;
 import net.imglib2.img.sparse.NtreeImg;
 import net.imglib2.img.sparse.NtreeImgFactory;
-import net.imglib2.type.BooleanType;
-import net.imglib2.type.logic.BitType;
-import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.roi.sparse.labkit.SparseIterableRegion;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -22,14 +21,20 @@ public class SparseBitmaskBenchmark
 {
 	@Benchmark
 	public void benchmark() {
-		SparseBitmask bitmask = new SparseBitmask( 2 );
-		fillHypersphere( bitmask, 50, 50, 50 );
+		SparseBitmask image = new SparseBitmask( 3 );
+		fillHypersphere( image, 50, 50, 50, 50 );
 	}
 
 	@Benchmark
 	public void benchmarkNDTree() {
-		NtreeImg< UnsignedByteType, ? > image = new NtreeImgFactory<>( new UnsignedByteType() ).create( 100, 100 );
-		fillHypersphere( image, 50, 50, 50 );
+		NtreeImg< UnsignedByteType, ? > image = new NtreeImgFactory<>( new UnsignedByteType() ).create( 100, 100, 100 );
+		fillHypersphere( image, 50, 50, 50, 50 );
+	}
+
+	@Benchmark
+	public void labkitSparse() {
+		SparseIterableRegion image = new SparseIterableRegion( new FinalInterval( 100, 100, 100 ) );
+		fillHypersphere( image, 50, 50, 50, 50 );
 	}
 
 	public static void main( final String... args ) throws RunnerException

--- a/src/test/java/net/imglib2/roi/sparse/SparseBitmaskExample.java
+++ b/src/test/java/net/imglib2/roi/sparse/SparseBitmaskExample.java
@@ -1,0 +1,57 @@
+package net.imglib2.roi.sparse;
+
+import bdv.util.Bdv;
+import bdv.util.BdvFunctions;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.neighborhood.HyperSphereShape;
+import net.imglib2.algorithm.neighborhood.Neighborhood;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+
+/**
+ * Using {@code SparseBitmask} as a (unbounded) {@code RandomAccessible<NativeBoolType>}.
+ *
+ * @author Tobias Pietzsch
+ */
+public class SparseBitmaskExample
+{
+	public static void main( String[] args )
+	{
+		/*
+		 * Create a 2D SparseBitmask.
+		 * SparseBitmask is a RandomAccessible<NativeBoolType>.
+		 */
+		final SparseBitmask bitmask = new SparseBitmask( 2 );
+
+		/*
+		 * Paint some stuff.
+		 * bitmask grows as needed.
+		 */
+		Views.interval( bitmask, Intervals.createMinSize( 70, 140, 80, 40 ) ).forEach( t -> t.set( true ) );
+		fillHypersphere( bitmask, 100, 100, 20 );
+		fillHypersphere( bitmask, 50, 10, 200 );
+//		fillHypersphere( bitmask, 500, -10000, -200 );
+//		fillHypersphere( bitmask, 5000, 1000, 20000 );
+
+		/*
+		 * Display in BDV.
+		 * bitmask is an unbounded RandomAccessible, so we need to provide an Interval.
+		 */
+		BdvFunctions.show( bitmask, Intervals.createMinSize( 0, 0, 1000, 1000 ), "bitmask", Bdv.options().is2D() );
+
+		/*
+		 * Alternatively, we could use SparseBitmask.region(), which provides a (read-only) view as an IterableRegion<NativeBoolType>.
+		 * The interval of bitmask.region() is the current bounding box of the set pixels in the bitmask.
+		 */
+//		BdvFunctions.show( bitmask.region(), "bitmask", Bdv.options().is2D() );
+	}
+
+	private static void fillHypersphere( RandomAccessible< NativeBoolType > img, long radius, long... position )
+	{
+		final RandomAccess< Neighborhood< NativeBoolType > > a = new HyperSphereShape( radius ).neighborhoodsRandomAccessible( img ).randomAccess();
+		a.setPosition( position );
+		a.get().forEach( t -> t.set( true ) );
+	}
+}

--- a/src/test/java/net/imglib2/roi/sparse/SparseBitmaskExampleIterableRegion.java
+++ b/src/test/java/net/imglib2/roi/sparse/SparseBitmaskExampleIterableRegion.java
@@ -1,0 +1,67 @@
+package net.imglib2.roi.sparse;
+
+import bdv.util.Bdv;
+import bdv.util.BdvFunctions;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.HyperSphereShape;
+import net.imglib2.algorithm.neighborhood.Neighborhood;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.roi.IterableRegion;
+import net.imglib2.roi.Regions;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+
+/**
+ * Using {@code SparseBitmask.region()} as an {@code IterableRegion}.
+ *
+ * @author Tobias Pietzsch
+ */
+public class SparseBitmaskExampleIterableRegion
+{
+	public static void main( String[] args )
+	{
+		/*
+		 * Create and paint to a 2D bitmask.
+		 */
+		final SparseBitmask bitmask = new SparseBitmask( 2 );
+		fillHypersphere( bitmask, 100, 100, 20 );
+		fillHypersphere( bitmask, 50, 10, 200 );
+
+		/*
+		 * SparseBitmask.region() provides a (read-only) view as an IterableRegion<NativeBoolType>.
+		 * The interval of bitmask.region() is the bounding box of the set pixels in the bitmask.
+		 * The Cursor<Void> of the region visits the set (true) pixels in the bitmask.
+		 * We use it to set pixels in a ArrayImg.
+		 */
+		final IterableRegion< NativeBoolType > region = bitmask.region();
+		final Img< ARGBType > img = ArrayImgs.argbs( Intervals.dimensionsAsLongArray( region ) );
+		final RandomAccessibleInterval< ARGBType > translated = Views.translate( img, Intervals.minAsLongArray( region ) );
+		Regions.sample( region, translated ).forEach( t -> t.set( 0x0000ff00 ) );
+
+		/*
+		 * or more verbosely
+		 */
+//		final Cursor< Void > c = region.cursor();
+//		final RandomAccess< ARGBType > a = translated.randomAccess();
+//		while ( c.hasNext() )
+//		{
+//			c.fwd();
+//			a.setPosition( c );
+//			a.get().set( 0x0000ff00 );
+//		}
+
+		BdvFunctions.show( img, "img", Bdv.options().is2D() );
+	}
+
+	private static void fillHypersphere( RandomAccessible< NativeBoolType > img, long radius, long... position )
+	{
+		final RandomAccess< Neighborhood< NativeBoolType > > a = new HyperSphereShape( radius ).neighborhoodsRandomAccessible( img ).randomAccess();
+		a.setPosition( position );
+		a.get().forEach( t -> t.set( true ) );
+	}
+}

--- a/src/test/java/net/imglib2/roi/sparse/SparseBitmaskExampleShowTree.java
+++ b/src/test/java/net/imglib2/roi/sparse/SparseBitmaskExampleShowTree.java
@@ -1,0 +1,107 @@
+package net.imglib2.roi.sparse;
+
+import bdv.util.Bdv;
+import bdv.util.BdvFunctions;
+import bdv.util.BdvOverlay;
+import bdv.util.BdvSource;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RealPoint;
+import net.imglib2.algorithm.neighborhood.HyperSphereShape;
+import net.imglib2.algorithm.neighborhood.Neighborhood;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.roi.sparse.SparseBitmaskNTree.Node;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.type.numeric.ARGBType;
+
+/**
+ * Visualize the quadtree underlying a (2D) SparseBitmask.
+ *
+ * @author Tobias Pietzsch
+ */
+public class SparseBitmaskExampleShowTree
+{
+	public static void main( String[] args )
+	{
+		/*
+		 * Create, paint, and display 2D bitmask.
+		 */
+		final SparseBitmask bitmask = new SparseBitmask( 2 );
+		fillHypersphere( bitmask, 100, 100, 20 );
+		fillHypersphere( bitmask, 50, 10, 200 );
+		fillHypersphere( bitmask, 500, -10000, -200 );
+		fillHypersphere( bitmask, 5000, 1000, 20000 );
+		Bdv bdv = BdvFunctions.show( bitmask.region(), "bitmask", Bdv.options().is2D() );
+
+		/*
+		 * Add BDV overlay to display a bunch of Intervals.
+		 */
+		final IntervalsOverlay nodes = new IntervalsOverlay();
+		final BdvSource nodesSource = BdvFunctions.showOverlay( nodes, "nodes", Bdv.options().addTo( bdv ) );
+		nodesSource.setColor( new ARGBType( 0x00ff0000 ) );
+
+		/*
+		 * Iterate all nodes of the quadtree backing the bitmask,
+		 * adding the node intervals to the overlay.
+		 */
+		bitmask.tree().forEach( ( Node node ) -> nodes.add( node.interval() ) );
+	}
+
+	private static void fillHypersphere( RandomAccessible< NativeBoolType > img, long radius, long... position )
+	{
+		final RandomAccess< Neighborhood< NativeBoolType > > a = new HyperSphereShape( radius ).neighborhoodsRandomAccessible( img ).randomAccess();
+		a.setPosition( position );
+		a.get().forEach( t -> t.set( true ) );
+	}
+
+	/**
+	 * Helper to paint some Intervals as a BDV overlay
+	 */
+	static class IntervalsOverlay extends BdvOverlay
+	{
+		private final List< Consumer< Graphics2D > > intervalPainters = new ArrayList<>();
+
+		public synchronized  void add( final Interval interval )
+		{
+			final RealPoint[] points = new RealPoint[] {
+					new RealPoint( interval.min( 0 ) - 0.5, interval.min( 1 ) - 0.5 ),
+					new RealPoint( interval.min( 0 ) - 0.5, interval.max( 1 ) + 0.5 ),
+					new RealPoint( interval.max( 0 ) + 0.5, interval.max( 1 ) + 0.5 ),
+					new RealPoint( interval.max( 0 ) + 0.5, interval.min( 1 ) - 0.5 ),
+			};
+			intervalPainters.add( graphics -> {
+				final Color col = new Color( info.getColor().get() );
+				final AffineTransform3D transform = new AffineTransform3D();
+				getCurrentTransform3D( transform );
+				final double[] lPos = new double[ 3 ];
+				final double[] gPos = new double[ 3 ];
+				for ( int i = 0; i < points.length; i++ )
+				{
+					final int j = ( i + 1 ) % points.length;
+					points[ i ].localize( lPos );
+					transform.apply( lPos, gPos );
+					final int x1 = ( int ) gPos[ 0 ];
+					final int y1 = ( int ) gPos[ 1 ];
+					points[ j ].localize( lPos );
+					transform.apply( lPos, gPos );
+					final int x2 = ( int ) gPos[ 0 ];
+					final int y2 = ( int ) gPos[ 1 ];
+					graphics.setColor( col );
+					graphics.drawLine( x1, y1, x2, y2 );
+				}
+			} );
+		}
+
+		@Override
+		protected synchronized void draw( final Graphics2D graphics )
+		{
+			intervalPainters.forEach( c -> c.accept( graphics ) );
+		}
+	}
+}

--- a/src/test/java/net/imglib2/roi/sparse/SparseBitmaskTest.java
+++ b/src/test/java/net/imglib2/roi/sparse/SparseBitmaskTest.java
@@ -1,0 +1,50 @@
+package net.imglib2.roi.sparse;
+
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.roi.IterableRegion;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.util.Localizables;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class SparseBitmaskTest
+{
+	@Test
+	public void testCreate() {
+		new SparseBitmask( 3 );
+	}
+
+	@Test
+	public void testRandomAccess() {
+		SparseBitmask bitmask = new SparseBitmask( 3 );
+		RandomAccess< NativeBoolType > ra = bitmask.randomAccess();
+		ra.get().set( true );
+		assertTrue( ra.get().get() );
+		ra.get().set( false );
+		assertFalse( ra.get().get() );
+	}
+
+
+	@Test
+	public void testRegion() {
+		SparseBitmask bitmask = new SparseBitmask( 3 );
+		RandomAccess< NativeBoolType > ra = bitmask.randomAccess();
+		final long[] position = { 1, 2, 3 };
+		ra.setPosition( position );
+		ra.get().set( true );
+		final IterableRegion< NativeBoolType > region = bitmask.region();
+		Cursor< Void > cursor = region.cursor();
+		assertEquals(1, region.size());
+		assertTrue( cursor.hasNext() );
+		cursor.next();
+		assertArrayEquals( position, Localizables.asLongArray( cursor ) );
+		assertFalse( cursor.hasNext() );
+	}
+
+
+}

--- a/src/test/java/net/imglib2/roi/sparse/labkit/IntervalIndexer2.java
+++ b/src/test/java/net/imglib2/roi/sparse/labkit/IntervalIndexer2.java
@@ -1,0 +1,54 @@
+
+package net.imglib2.roi.sparse.labkit;
+
+import net.imglib2.Interval;
+import net.imglib2.Localizable;
+import net.imglib2.Positionable;
+import net.imglib2.util.Intervals;
+
+import java.util.stream.LongStream;
+
+/**
+ * @author Matthias Arzt
+ */
+public class IntervalIndexer2
+{
+
+	private final long[] min;
+	private final long[] dimensions;
+	private final long[] stepSize;
+
+	public IntervalIndexer2(final Interval interval) {
+		min = Intervals.minAsLongArray(interval);
+		dimensions = Intervals.dimensionsAsLongArray(interval);
+		stepSize = initStepStepSize();
+	}
+
+	private long[] initStepStepSize() {
+		long[] stepSize = new long[dimensions.length];
+		stepSize[0] = 1;
+		for (int i = 1; i < dimensions.length; i++)
+			stepSize[i] = stepSize[i - 1] * dimensions[i - 1];
+		return stepSize;
+	}
+
+	public long size() {
+		return LongStream.of(dimensions).reduce(1, (a, b) -> a * b);
+	}
+
+	public long positionToIndex(Localizable localizable) {
+		long sum = 0;
+		for (int d = 0; d < dimensions.length; ++d)
+			sum += stepSize[d] * (localizable.getLongPosition(d) - min[d]);
+		return sum;
+	}
+
+	public void indexToPosition(long index, Positionable positionable) {
+		for (int d = 0; d < dimensions.length; ++d)
+			positionable.setPosition(indexToPosition(index, d), d);
+	}
+
+	public long indexToPosition(long index, int d) {
+		return index / stepSize[d] % dimensions[d] + min[d];
+	}
+}

--- a/src/test/java/net/imglib2/roi/sparse/labkit/SparseIterableRegion.java
+++ b/src/test/java/net/imglib2/roi/sparse/labkit/SparseIterableRegion.java
@@ -1,0 +1,195 @@
+
+package net.imglib2.roi.sparse.labkit;
+
+import gnu.trove.set.TLongSet;
+import gnu.trove.set.hash.TLongHashSet;
+import net.imglib2.AbstractCursor;
+import net.imglib2.AbstractWrappedInterval;
+import net.imglib2.Cursor;
+import net.imglib2.Interval;
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.Sampler;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.roi.IterableRegion;
+import net.imglib2.type.logic.BitType;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+/**
+ * @author Matthias Arzt
+ */
+public class SparseIterableRegion extends AbstractWrappedInterval<Interval>
+	implements IterableRegion<BitType>
+{
+
+	final private TLongSet codes;
+
+	final private IntervalIndexer2 indexer;
+
+	public SparseIterableRegion(Interval interval) {
+		this(interval, new TLongHashSet());
+	}
+
+	public SparseIterableRegion(Interval interval, TLongSet positions) {
+		super(interval);
+		this.codes = positions;
+		this.indexer = new IntervalIndexer2(interval);
+	}
+
+	public void add(Localizable position) {
+		codes.add(indexer.positionToIndex(position));
+	}
+
+	public void remove(Localizable position) {
+		codes.remove(indexer.positionToIndex(position));
+	}
+
+	private boolean contains(Localizable position) {
+		return codes.contains(indexer.positionToIndex(position));
+	}
+
+	@Override
+	public Cursor<Void > cursor() {
+		return new SparseRoiCursor();
+	}
+
+	@Override
+	public Cursor<Void > localizingCursor() {
+		return cursor();
+	}
+
+	@Override
+	public long size() {
+		return codes.size();
+	}
+
+	@Override
+	public Void firstElement() {
+		return null;
+	}
+
+	@Override
+	public Object iterationOrder() {
+		return null;
+	}
+
+	@Override
+	public Iterator<Void> iterator() {
+		return cursor();
+	}
+
+	@Override
+	public RandomAccess<BitType> randomAccess() {
+		return new SparseRoiRandomAccess();
+	}
+
+	@Override
+	public RandomAccess<BitType> randomAccess(Interval interval) {
+		return randomAccess();
+	}
+
+	private class SparseRoiCursor extends AbstractCursor<Void > implements
+		Cursor<Void >
+	{
+
+		private final long[] sortedCodes;
+		private final int lastIndex;
+		private final Point point;
+		private int i;
+
+		private SparseRoiCursor() {
+			super(SparseIterableRegion.this.numDimensions());
+			point = new Point(SparseIterableRegion.this.numDimensions());
+			sortedCodes = codes.toArray();
+			Arrays.sort(sortedCodes);
+			lastIndex = sortedCodes.length - 1;
+			reset();
+		}
+
+		@Override
+		public Void get() {
+			return null;
+		}
+
+		@Override
+		public AbstractCursor<Void > copy() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public AbstractCursor<Void > copyCursor() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void fwd() {
+			i++;
+			indexer.indexToPosition(sortedCodes[i], point);
+		}
+
+		@Override
+		public void reset() {
+			i = -1;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return i < lastIndex;
+		}
+
+		@Override
+		public void localize(long[] position) {
+			point.localize(position);
+		}
+
+		@Override
+		public long getLongPosition(int d) {
+			return point.getLongPosition(d);
+		}
+	}
+
+	private class SparseRoiRandomAccess extends Point implements
+		RandomAccess<BitType>
+	{
+
+		private BitType value = new BitType(new LongArray(1)) {
+
+			@Override
+			public void set(boolean value) {
+				if (value) SparseIterableRegion.this.add(SparseRoiRandomAccess.this);
+				else remove(SparseRoiRandomAccess.this);
+			}
+
+			@Override
+			public boolean get() {
+				return contains(SparseRoiRandomAccess.this);
+			}
+		};
+
+		private SparseRoiRandomAccess() {
+			super(SparseIterableRegion.this.numDimensions());
+		}
+
+		private SparseRoiRandomAccess(Localizable localizable) {
+			super(localizable);
+		}
+
+		@Override
+		public RandomAccess<BitType> copyRandomAccess() {
+			return new SparseRoiRandomAccess(this);
+		}
+
+		@Override
+		public BitType get() {
+			return value;
+		}
+
+		@Override
+		public Sampler<BitType> copy() {
+			throw new UnsupportedOperationException();
+		}
+	}
+}


### PR DESCRIPTION
`SparseBitmask` is a `RandomAccessible<BoolType>` based on *n*Tree (quadtree, octree, ...) with little bitmasks (basically `ArrayImg<BitType>`) in the leafs. It's a `RandomAccessible` (not `Interval`). The tree grows on demand, just set pixels wherever...

There are efficient algorithms for
 * computation of bounding box of set (`true`) pixels,
 * iteration of set (`true`) pixels.

These are provided through a (read-only) view as an `IterableRegion`.

Some usage examples are in src/test/.

![sparsetree](https://user-images.githubusercontent.com/622070/50832760-7521bc00-134f-11e9-9a36-b062e02c5524.gif)

I'm happy with the underlying tree and bitmask stuff (`SparseBitmaskNTree`, `Tree`, `GrowableTree`).
However, packaging as a `RandomAccessible` in `SparseBitmask` required some trade-offs that are not so clear and depend on use case. I would be happy about some input...

In particular, read/write of pixels is protected by a `ReentrantReadWriteLock` that is acquired per pixel access. It would be nice to have this more coarse-grained, but I don't know how.

Also, `SparseBitmask.region()` provides `IterableRegion` view of the current state, and will throw `ConcurrentModificationException` when the bitmask is modified. There are some minor trade-offs there as well, but read/write locking is the major problem.

