### PR TITLE
Improve the Regions class

### DIFF
--- a/src/main/java/net/imglib2/roi/Regions.java
+++ b/src/main/java/net/imglib2/roi/Regions.java
@@ -67,7 +67,7 @@ public class Regions
 	 */
 	public static < T > IterableInterval< T > sample( final RealMaskRealInterval mask, final RandomAccessible< T > img )
 	{
-		return Regions.sample( Masks.toIterableRegion( mask ), img );
+		return sample( Masks.toIterableRegion( mask ), img );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/roi/Regions.java
+++ b/src/main/java/net/imglib2/roi/Regions.java
@@ -71,6 +71,46 @@ public class Regions
 	}
 
 	/**
+	 * Given a mask and an image, return an {@link IterableInterval}
+	 * over the pixels of the image inside the mask.
+	 * 
+	 * @param mask The mask that defines which pixels in {@code img} to iterate over.
+	 * @param img The source from which to grab the pixels inside the mask.
+	 * @return An IterableInterval over the samples of img inside the mask.
+	 */
+	public static < T, B extends BooleanType<B> > IterableInterval< T > sample( final RandomAccessible< B > mask, final RandomAccessibleInterval< T > img )
+	{
+		final IterableInterval< Void > region = iterable( Views.interval( mask, img ) );
+		return sample( region, img );
+	}
+
+	/**
+	 * Given a mask and an image, return an {@link IterableInterval}
+	 * over the pixels of the image inside the mask.
+	 * 
+	 * @param mask The mask that defines which pixels in {@code img} to iterate over.
+	 * @param img The source from which to grab the pixels inside the mask.
+	 * @return An IterableInterval over the samples of img inside the mask.
+	 */
+	public static < T > IterableInterval< T > sample( final Mask mask, final RandomAccessibleInterval< T > img )
+	{
+		return sample( Masks.toRandomAccessible( mask ), img );
+	}
+
+	/**
+	 * Given a mask and an image, return an {@link IterableInterval}
+	 * over the pixels of the image inside the mask.
+	 * 
+	 * @param mask The mask that defines which pixels in {@code img} to iterate over.
+	 * @param img The source from which to grab the pixels inside the mask.
+	 * @return An IterableInterval over the samples of img inside the mask.
+	 */
+	public static < T > IterableInterval< T > sample( final RealMask mask, final RandomAccessibleInterval< T > img )
+	{
+		return sample( Views.raster( Masks.toRealRandomAccessible( mask ) ), img );
+	}
+
+	/**
 	 * Obtains an {@link IterableRegion} whose iteration consists of only the
 	 * true pixels of a region (instead of all pixels in bounding box).
 	 * 

--- a/src/main/java/net/imglib2/roi/Regions.java
+++ b/src/main/java/net/imglib2/roi/Regions.java
@@ -98,10 +98,10 @@ public class Regions
 	 *            The region whose true values should be counted.
 	 * @return The number of true values in the region.
 	 */
-	public static < T extends BooleanType< T > > long countTrue( final RandomAccessibleInterval< T > interval )
+	public static < B extends BooleanType< B > > long countTrue( final RandomAccessibleInterval< B > interval )
 	{
 		long sum = 0;
-		for ( final T t : Views.iterable( interval ) )
+		for ( final B t : Views.iterable( interval ) )
 			if ( t.get() )
 				++sum;
 		return sum;

--- a/src/main/java/net/imglib2/roi/Regions.java
+++ b/src/main/java/net/imglib2/roi/Regions.java
@@ -44,6 +44,14 @@ import net.imglib2.view.Views;
 public class Regions
 {
 
+	/**
+	 * Given a region and an image, return an {@link IterableInterval}
+	 * over the pixels of the image inside the mask.
+	 * 
+	 * @param region The region that defines which pixels in {@code img} to iterate over.
+	 * @param img The source from which to grab the pixels inside the region.
+	 * @return An IterableInterval over the samples of img inside the region.
+	 */
 	public static < T > IterableInterval< T > sample( final IterableInterval< Void > region, final RandomAccessible< T > img )
 	{
 		return SamplingIterableInterval.create( region, img );
@@ -62,6 +70,17 @@ public class Regions
 		return Regions.sample( Masks.toIterableRegion( mask ), img );
 	}
 
+	/**
+	 * Obtains an {@link IterableRegion} whose iteration consists of only the
+	 * true pixels of a region (instead of all pixels in bounding box).
+	 * 
+	 * @param <B>
+	 *            The {@link BooleanType} of the region.
+	 * @param region
+	 *            The region to filter by its true values.
+	 * @return An {@link IterableRegion} consisting of true values of the input
+	 *         region.
+	 */
 	public static < B extends BooleanType< B > > IterableRegion< B > iterable( final RandomAccessibleInterval< B > region )
 	{
 		if ( region instanceof IterableRegion )
@@ -70,6 +89,15 @@ public class Regions
 			return IterableRandomAccessibleRegion.create( region );
 	}
 
+	/**
+	 * Counts the number of true pixels in the given region.
+	 * 
+	 * @param <B>
+	 *            The {@link BooleanType} of the region.
+	 * @param interval
+	 *            The region whose true values should be counted.
+	 * @return The number of true values in the region.
+	 */
 	public static < T extends BooleanType< T > > long countTrue( final RandomAccessibleInterval< T > interval )
 	{
 		long sum = 0;

--- a/src/main/java/net/imglib2/roi/Regions.java
+++ b/src/main/java/net/imglib2/roi/Regions.java
@@ -43,9 +43,6 @@ import net.imglib2.view.Views;
 
 public class Regions
 {
-	// TODO: make Positionable and Localizable
-	// TODO: bind to (respectively sample from) RandomAccessible
-	// TODO: out-of-bounds / clipping
 
 	public static < T > IterableInterval< T > sample( final IterableInterval< Void > region, final RandomAccessible< T > img )
 	{


### PR DESCRIPTION
In particular, add three new `Regions.sample` signatures.

Previously, there was no one-liner for binding a `RealMask` to a `RandomAccessibleInterval`. We [covered it in the Learnathon's imagej-roi-course](https://github.com/maarzt/imagej-roi-course/blob/b3c5fae428bb831d847b15030d1509a1dd8f0ef6/src/main/java/de/mpicbg/learnathon/course/rois/exercise3/IterableRegionsExample.java#L52-L60), but it was not intuitive. I would not expect new users of ImgLib2 to ever be able to figure out how to combine these utility functions, or even necessarily know about them, since they are spread across `Views`, `Masks` and `Regions`. Even knowing these methods are there in the back of my mind, I still forget exactly what needs to be converted to what in order to bind stuff together. So I'm in favor of introducing more convenience functions, to ease the pain.

There are no tests, because `Regions` didn't have tests before. 😞  @tpietzsch @awalter17 If you like this change, but are too uncomfortable with the lack of tests, I'll add some; let me know.