### PR TITLE
Positionable Regions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,5 +203,17 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 			<artifactId>junit-benchmarks</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.21</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.21</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/net/imglib2/roi/IterableRegion.java
+++ b/src/main/java/net/imglib2/roi/IterableRegion.java
@@ -38,18 +38,27 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.BooleanType;
 
 /**
- * Iteration of only the true pixels of a region (instead of all pixels in
- * bounding box).
- *
+ * A region that allows to iterate only the pixels contained in the region
+ * (instead of all pixels in bounding box).
  * <p>
- * We put interfaces {@link RandomAccessibleInterval
- * RandomAccessibleInterval&lt;BooleanType&gt;}, {@link IterableRegion
- * IterableRegion&lt;BooleanType&gt;}, {@link PositionableIterableRegion
- * PositionableIterableRegion&lt;BooleanType&gt;} into this sequence such that
+ * Specifically, a region is a {@code RandomAccessibleInterval} of some
+ * {@code BooleanType} having value {@code true} for all pixels contained in the
+ * region. The interval is a (not necessarily tight) bounding box of the region,
+ * i.e., it is assumed that all pixels outside the interval have value
+ * {@code false}.
+ * <p>
+ * Iterating only the pixels contained in the region is indicated by
+ * {@code IterableInterval<Void>}, i.e., when iterating, only the coordinates
+ * that are visited are interesting. There is no associated value.
+ * <p>
+ * We put interfaces {@code RandomAccessibleInterval<BooleanType>}, extended by
+ * {@code IterableRegion<BooleanType>}, extended by
+ * {@code PositionableIterableRegion<BooleanType>} into this sequence such that
  * the {@link Regions} methods that "add capabilities" (being iterable,
  * positionable) can have appropriate result types.
  *
  * @param <T>
+ *            some {@code BooleanType} indicating containment in region
  *
  * @author Tobias Pietzsch
  */

--- a/src/main/java/net/imglib2/roi/PositionableIterableInterval.java
+++ b/src/main/java/net/imglib2/roi/PositionableIterableInterval.java
@@ -1,4 +1,4 @@
-/*
+/*-
  * #%L
  * ImgLib2: a general-purpose, multidimensional image processing library.
  * %%
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -33,25 +33,54 @@
  */
 package net.imglib2.roi;
 
-import net.imglib2.type.BooleanType;
+import net.imglib2.IterableInterval;
+import net.imglib2.Localizable;
+import net.imglib2.Positionable;
+import net.imglib2.roi.util.PositionableLocalizable;
+import net.imglib2.type.logic.BitType;
 
 /**
- * An {@link IterableRegion} that can be moved around.
+ * An {@link IterableInterval} that can be moved around.
  * <p>
- * We put interfaces {@code RandomAccessibleInterval<BooleanType>}, extended by
- * {@code IterableRegion<BooleanType>}, extended by
- * {@code PositionableIterableRegion<BooleanType>} into this sequence such that
- * the {@link Regions} methods that "add capabilities" (being iterable,
- * positionable) can have appropriate result types.
+ * {@code PositionableIterableInterval} is mainly intended as a return type. It
+ * is discouraged to take {@code PositionableIterableInterval} as a method
+ * parameter. {@code IterableInterval<T> & Localizable & Positionable} should be
+ * preferred where possible.
  *
  * @param <T>
- *            some {@code BooleanType} indicating containment in region
+ *            pixel type
  *
  * @author Tobias Pietzsch
  */
-public interface PositionableIterableRegion< T extends BooleanType< T > >
-	extends IterableRegion< T >, PositionableIterableInterval< Void >
+public interface PositionableIterableInterval< T > extends IterableInterval< T >, Localizable, Positionable
 {
-	@Override
-	public PositionableIterableRegion< T > copy();
+	/**
+	 * Get the {@link Positionable}, {@link Localizable} origin of this
+	 * interval.
+	 * <p>
+	 * The origin is the relative offset of the position to the minimum. For
+	 * example if a positionable (bitmask) region is made from a {@link BitType}
+	 * image with a circular pattern, then it is more natural if the region
+	 * position refers to the center of the pattern instead of the upper left
+	 * corner of the {@link BitType} image. This can be achieved by positioning
+	 * the origin.
+	 * <p>
+	 * Assume a region is created from a 9x9 bitmask. The region initially has
+	 * min=(0,0), max=(8,8), position=(0,0). Because both position and min are
+	 * (0,0), initially origin=(0,0). Now assume the origin is moved to the
+	 * center of the bitmask using
+	 * <code>origin().setPosition(new int[]{4,4})</code>. After this,
+	 * min=(-4,-4), max=(4,4), position=(0,0), and origin=(4,4).
+	 *
+	 * @return the origin to which the interval is relative.
+	 */
+	public PositionableLocalizable origin();
+
+	/**
+	 * Make a copy of this {@link PositionableIterableInterval} which can be
+	 * positioned independently.
+	 *
+	 * @return a copy with an independent position
+	 */
+	public PositionableIterableInterval< T > copy();
 }

--- a/src/main/java/net/imglib2/roi/Regions.java
+++ b/src/main/java/net/imglib2/roi/Regions.java
@@ -36,7 +36,7 @@ package net.imglib2.roi;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.roi.util.IterableRandomAccessibleRegion;
+import net.imglib2.roi.util.IterableRegionOnBooleanRAI;
 import net.imglib2.roi.util.PositionableWrappedIterableRegion;
 import net.imglib2.roi.util.SamplingIterableInterval;
 import net.imglib2.type.BooleanType;
@@ -146,7 +146,7 @@ public class Regions
 		if ( region instanceof IterableRegion )
 			return ( IterableRegion< B > ) region;
 		else
-			return IterableRandomAccessibleRegion.create( region );
+			return new IterableRegionOnBooleanRAI<>( region );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/roi/Regions.java
+++ b/src/main/java/net/imglib2/roi/Regions.java
@@ -128,6 +128,10 @@ public class Regions
 	/**
 	 * Obtains an {@link IterableRegion} whose iteration consists of only the
 	 * true pixels of a region (instead of all pixels in bounding box).
+	 * <p>
+	 * If {@code region} already is an {@code IterableRegion}, return it.
+	 * Otherwise, wrap it. This is potentially expensive, because it requires
+	 * iterating {@code region} once.
 	 *
 	 * @param <B>
 	 *     The {@link BooleanType} of the region.
@@ -145,6 +149,20 @@ public class Regions
 			return IterableRandomAccessibleRegion.create( region );
 	}
 
+	/**
+	 * Make any {@code RandomAccessibleInterval<BooleanType>} into an
+	 * {@code PositionableIterableRegion}.
+	 * <p>
+	 * If {@code region} already is a {@code PositionableIterableRegion}, return
+	 * it. Otherwise, wrap it. This is potentially expensive, because it
+	 * requires iterating {@code region} once, unless it already is an
+	 * {@code IterableRegion}.
+	 *
+	 * @param region
+	 *            the region to make iterable and positionable
+	 *
+	 * @return {@code region} as an {@code PositionableIterableRegion}
+	 */
 	public static < B extends BooleanType< B > > PositionableIterableRegion< B > positionable( final RandomAccessibleInterval< B > region )
 	{
 		if ( region instanceof PositionableIterableRegion )
@@ -171,14 +189,4 @@ public class Regions
 				++sum;
 		return sum;
 	}
-
-	// TODO make Positionable and Localizable: given a RandomAccessibleInterval<B>, return a PositionableIterableRegion<B>
-//	public static < B extends BooleanType< B > > PositionableIterableRegion< B > positionable( final RandomAccessibleInterval< B > region )
-//	{
-//		return positionable( iterable( region ) );
-//	}
-//	public static < B extends BooleanType< B > > PositionableIterableRegion< B > positionable( final IterableRegion< B > region )
-//	{
-//		...
-//	}
 }

--- a/src/main/java/net/imglib2/roi/Regions.java
+++ b/src/main/java/net/imglib2/roi/Regions.java
@@ -37,6 +37,7 @@ import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.roi.util.IterableRandomAccessibleRegion;
+import net.imglib2.roi.util.PositionableWrappedIterableRegion;
 import net.imglib2.roi.util.SamplingIterableInterval;
 import net.imglib2.type.BooleanType;
 import net.imglib2.view.Views;
@@ -142,6 +143,14 @@ public class Regions
 			return ( IterableRegion< B > ) region;
 		else
 			return IterableRandomAccessibleRegion.create( region );
+	}
+
+	public static < B extends BooleanType< B > > PositionableIterableRegion< B > positionable( final RandomAccessibleInterval< B > region )
+	{
+		if ( region instanceof PositionableIterableRegion )
+			return ( PositionableIterableRegion< B > ) region;
+		else
+			return new PositionableWrappedIterableRegion<>( Regions.iterable( region ) );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/roi/labeling/LabelRegionCursor.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelRegionCursor.java
@@ -33,72 +33,22 @@
  */
 package net.imglib2.roi.labeling;
 
-import gnu.trove.list.array.TIntArrayList;
-
 import java.util.ArrayList;
 
-import net.imglib2.AbstractLocalizable;
-import net.imglib2.Cursor;
-import net.imglib2.Point;
-import net.imglib2.roi.util.iterationcode.IterationCodeListIterator;
+import net.imglib2.roi.util.iterationcode.IterationCodeListCursor;
 
-public class LabelRegionCursor extends AbstractLocalizable implements Cursor< Void >
+import gnu.trove.list.array.TIntArrayList;
+
+public class LabelRegionCursor extends IterationCodeListCursor
 {
-	private final IterationCodeListIterator< Point > iter;
-
 	public LabelRegionCursor( final ArrayList< TIntArrayList > itcodesList, final long[] offset )
 	{
-		super( offset.length );
-		iter = new IterationCodeListIterator< Point >( itcodesList, offset, Point.wrap( position ) );
+		super( itcodesList, offset );
 	}
 
 	protected LabelRegionCursor( final LabelRegionCursor c )
 	{
-		super( c.n );
-		iter = new IterationCodeListIterator< Point >( c.iter, Point.wrap( position ) );
-	}
-
-	@Override
-	public Void get()
-	{
-		return null;
-	}
-
-	@Override
-	public void jumpFwd( final long steps )
-	{
-		iter.jumpFwd( steps );
-	}
-
-	@Override
-	public void fwd()
-	{
-		iter.fwd();
-	}
-
-	@Override
-	public void reset()
-	{
-		iter.reset();
-	}
-
-	@Override
-	public boolean hasNext()
-	{
-		return iter.hasNext();
-	}
-
-	@Override
-	public Void next()
-	{
-		fwd();
-		return null;
-	}
-
-	@Override
-	public void remove()
-	{
-		// NB: no action.
+		super( c );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/roi/util/IterableRandomAccessibleRegion.java
+++ b/src/main/java/net/imglib2/roi/util/IterableRandomAccessibleRegion.java
@@ -63,7 +63,7 @@ public class IterableRandomAccessibleRegion< T extends BooleanType< T > >
 
 	public static < T extends BooleanType< T > > IterableRandomAccessibleRegion< T > create( final RandomAccessibleInterval< T > interval )
 	{
-		return new IterableRandomAccessibleRegion< T >( interval, Regions.countTrue( interval ) );
+		return new IterableRandomAccessibleRegion<>( interval, Regions.countTrue( interval ) );
 	}
 
 	public IterableRandomAccessibleRegion( final RandomAccessibleInterval< T > interval, final long size )
@@ -101,7 +101,7 @@ public class IterableRandomAccessibleRegion< T extends BooleanType< T > >
 	@Override
 	public Cursor< Void > cursor()
 	{
-		return new RandomAccessibleRegionCursor< T >( sourceInterval, size );
+		return new RandomAccessibleRegionCursor<>( sourceInterval, size );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/roi/util/IterableRandomAccessibleRegion.java
+++ b/src/main/java/net/imglib2/roi/util/IterableRandomAccessibleRegion.java
@@ -56,6 +56,7 @@ import net.imglib2.type.BooleanType;
  *
  * @author Tobias Pietzsch
  */
+@Deprecated
 public class IterableRandomAccessibleRegion< T extends BooleanType< T > >
 	extends AbstractWrappedInterval< RandomAccessibleInterval< T > > implements IterableRegion< T >
 {

--- a/src/main/java/net/imglib2/roi/util/IterableRegionOnBooleanRAI.java
+++ b/src/main/java/net/imglib2/roi/util/IterableRegionOnBooleanRAI.java
@@ -1,0 +1,126 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import net.imglib2.AbstractWrappedInterval;
+import net.imglib2.Cursor;
+import net.imglib2.Interval;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.roi.IterableRegion;
+import net.imglib2.roi.Regions;
+import net.imglib2.type.BooleanType;
+import net.imglib2.view.Views;
+
+/**
+ * Wrap a boolean {@link RandomAccessibleInterval} as a {@link IterableRegion}.
+ * Cursors on the result only iterate {@code true} samples of the source interval.
+ *
+ * {@link Cursor Cursors} are realized by wrapping source cursors (using {@link TrueCursor}).
+ *
+ * @author Tobias Pietzsch
+ */
+public class IterableRegionOnBooleanRAI< T extends BooleanType< T > >
+		extends AbstractWrappedInterval< RandomAccessibleInterval< T > >
+		implements IterableRegion< T >
+{
+	private final long size;
+
+	private final IterableInterval< T > sourceIterable;
+
+	public IterableRegionOnBooleanRAI( final RandomAccessibleInterval< T > interval )
+	{
+		this( interval, Regions.countTrue( interval ) );
+	}
+
+	public IterableRegionOnBooleanRAI( final RandomAccessibleInterval< T > interval, final long size )
+	{
+		super( interval );
+		this.size = size;
+		sourceIterable = Views.iterable( interval );
+	}
+
+	@Override
+	public long size()
+	{
+		return size;
+	}
+
+	@Override
+	public Void firstElement()
+	{
+		if ( size() == 0 )
+			throw new NoSuchElementException();
+		return cursor().next();
+	}
+
+	@Override
+	public Object iterationOrder()
+	{
+		return this;
+	}
+
+	@Override
+	public Iterator< Void > iterator()
+	{
+		return cursor();
+	}
+
+	@Override
+	public Cursor< Void > cursor()
+	{
+		return new TrueCursor< T >( sourceIterable.cursor(), size );
+	}
+
+	@Override
+	public Cursor< Void > localizingCursor()
+	{
+		return new TrueCursor< T >( sourceIterable.localizingCursor(), size );
+	}
+
+	@Override
+	public RandomAccess< T > randomAccess()
+	{
+		return sourceInterval.randomAccess();
+	}
+
+	@Override
+	public RandomAccess< T > randomAccess( final Interval interval )
+	{
+		return sourceInterval.randomAccess( interval );
+	}
+}

--- a/src/main/java/net/imglib2/roi/util/OffsetLocalizable.java
+++ b/src/main/java/net/imglib2/roi/util/OffsetLocalizable.java
@@ -1,0 +1,111 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util;
+
+import net.imglib2.AbstractEuclideanSpace;
+import net.imglib2.Localizable;
+
+/**
+ * A {@link Localizable} that is the location of another {@link Localizable}
+ * plus an offset.
+ *
+ * @author Tobias Pietzsch
+ */
+public class OffsetLocalizable< L extends Localizable >
+		extends AbstractEuclideanSpace
+		implements Localizable
+{
+	protected L source;
+
+	protected long[] offset;
+
+	public OffsetLocalizable( final L source, final long[] offset )
+	{
+		super( source.numDimensions() );
+		this.source = source;
+		this.offset = offset;
+	}
+
+	@Override
+	public void localize( final float[] position )
+	{
+		for ( int d = 0; d < n; ++d )
+			position[ d ] = getFloatPosition( d );
+	}
+
+	@Override
+	public void localize( final double[] position )
+	{
+		for ( int d = 0; d < n; ++d )
+			position[ d ] = getDoublePosition( d );
+	}
+
+	@Override
+	public float getFloatPosition( final int d )
+	{
+		return source.getFloatPosition( d ) + offset[ d ];
+	}
+
+	@Override
+	public double getDoublePosition( final int d )
+	{
+		return source.getDoublePosition( d ) + offset[ d ];
+	}
+
+	@Override
+	public void localize( final int[] position )
+	{
+		for ( int d = 0; d < n; ++d )
+			position[ d ] = getIntPosition( d );
+	}
+
+	@Override
+	public void localize( final long[] position )
+	{
+		for ( int d = 0; d < n; ++d )
+			position[ d ] = getLongPosition( d );
+	}
+
+	@Override
+	public int getIntPosition( final int d )
+	{
+		return ( int ) ( source.getIntPosition( d ) + offset[ d ] );
+	}
+
+	@Override
+	public long getLongPosition( final int d )
+	{
+		return source.getLongPosition( d ) + offset[ d ];
+	}
+}

--- a/src/main/java/net/imglib2/roi/util/OffsetPositionableLocalizable.java
+++ b/src/main/java/net/imglib2/roi/util/OffsetPositionableLocalizable.java
@@ -1,0 +1,128 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util;
+
+import net.imglib2.Localizable;
+import net.imglib2.Positionable;
+
+/**
+ * A {@link Localizable} {@link Positionable} that is the position of another
+ * {@link Localizable} {@link Positionable} with an offset.
+ *
+ * @author Tobias Pietzsch
+ */
+public class OffsetPositionableLocalizable< P extends Positionable & Localizable >
+		extends OffsetLocalizable< P >
+		implements Positionable
+{
+	public OffsetPositionableLocalizable( final P source, final long[] offset )
+	{
+		super( source, offset );
+	}
+
+	@Override
+	public void fwd( final int d )
+	{
+		source.fwd( d );
+	}
+
+	@Override
+	public void bck( final int d )
+	{
+		source.bck( d );
+	}
+
+	@Override
+	public void move( final int distance, final int d )
+	{
+		source.move( distance, d );
+	}
+
+	@Override
+	public void move( final long distance, final int d )
+	{
+		source.move( distance, d );
+	}
+
+	@Override
+	public void move( final Localizable distance )
+	{
+		source.move( distance );
+	}
+
+	@Override
+	public void move( final int[] distance )
+	{
+		source.move( distance );
+	}
+
+	@Override
+	public void move( final long[] distance )
+	{
+		source.move( distance );
+	}
+
+	@Override
+	public void setPosition( final Localizable position )
+	{
+		for ( int d = 0; d < n; ++d )
+			source.setPosition( position.getLongPosition( d ) - offset[ d ], d );
+	}
+
+	@Override
+	public void setPosition( final int[] position )
+	{
+		for ( int d = 0; d < n; ++d )
+			source.setPosition( position[ d ] - offset[ d ], d );
+	}
+
+	@Override
+	public void setPosition( final long[] position )
+	{
+		for ( int d = 0; d < n; ++d )
+			source.setPosition( position[ d ] - offset[ d ], d );
+	}
+
+	@Override
+	public void setPosition( final int position, final int d )
+	{
+		source.setPosition( position - offset[ d ], d );
+	}
+
+	@Override
+	public void setPosition( final long position, final int d )
+	{
+		source.setPosition( position - offset[ d ], d );
+	}
+}

--- a/src/main/java/net/imglib2/roi/util/PositionableInterval.java
+++ b/src/main/java/net/imglib2/roi/util/PositionableInterval.java
@@ -1,0 +1,504 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util;
+
+import net.imglib2.AbstractLocalizable;
+import net.imglib2.Interval;
+import net.imglib2.Localizable;
+import net.imglib2.Positionable;
+import net.imglib2.RealPositionable;
+
+/**
+ * An interval that can be moved around.
+ * <p>
+ * It is constructed with an initial source interval. After construction it has
+ * position 0, and interval bounds that are identical to the initial source
+ * interval.
+ * <p>
+ * If after that it is moved, both the position and interval bounds move.
+ * <p>
+ * Additionally, it is possible to move the {@link #origin()}, which is useful
+ * for example to make the min corner or the center of the interval coincide
+ * with the position.
+ *
+ * @author Tobias Pietzsch
+ */
+public class PositionableInterval extends AbstractLocalizable implements Positionable, Interval
+{
+	protected final long[] currentOffset;
+
+	protected final long[] initialMin;
+
+	protected final long[] initialMax;
+
+	private final PositionableLocalizable origin;
+
+	public PositionableInterval( final Interval initial )
+	{
+		super( initial.numDimensions() );
+		currentOffset = new long[ n ];
+		initialMin = new long[ n ];
+		initialMax = new long[ n ];
+		initial.min( initialMin );
+		initial.max( initialMax );
+		origin = new Origin();
+	}
+
+	/**
+	 * Copy constructor.
+	 */
+	protected PositionableInterval( final PositionableInterval other )
+	{
+		super( other.numDimensions() );
+		currentOffset = other.currentOffset.clone();
+		initialMin = other.initialMin.clone();
+		initialMax = other.initialMax.clone();
+		origin = new Origin();
+	}
+
+	/**
+	 * Get the {@link Positionable}, {@link Localizable} origin of this
+	 * interval.
+	 * <p>
+	 * The origin is the relative offset of the position to the minimum. For
+	 * example if a positionable (bitmask) region is made from a {@code BitType}
+	 * image with a circular pattern, then it is more natural if the region
+	 * position refers to the center of the pattern instead of the upper left
+	 * corner of the {@code BitType} image. This can be achieved by positioning
+	 * the origin.
+	 * <p>
+	 * Assume a region is created from a 9x9 bitmask. The region initially has
+	 * min=(0,0), max=(8,8), position=(0,0). Because both position and min are
+	 * (0,0), initially origin=(0,0). Now assume the origin is moved to the
+	 * center of the bitmask using
+	 * <code>origin().setPosition(new int[]{4,4})</code>. After this,
+	 * min=(-4,-4), max=(4,4), position=(0,0), and origin=(4,4).
+	 *
+	 * @return the origin to which the interval is relative.
+	 */
+	public PositionableLocalizable origin()
+	{
+		return origin;
+	}
+
+	@Override
+	public void fwd( final int d )
+	{
+		++position[ d ];
+		++currentOffset[ d ];
+	}
+
+	@Override
+	public void bck( final int d )
+	{
+		--position[ d ];
+		--currentOffset[ d ];
+	}
+
+	@Override
+	public void move( final int distance, final int d )
+	{
+		position[ d ] += distance;
+		currentOffset[ d ] += distance;
+	}
+
+	@Override
+	public void move( final long distance, final int d )
+	{
+		position[ d ] += distance;
+		currentOffset[ d ] += distance;
+	}
+
+	@Override
+	public void move( final Localizable localizable )
+	{
+		for ( int d = 0; d < n; ++d )
+		{
+			final long distance = localizable.getLongPosition( d );
+			position[ d ] += distance;
+			currentOffset[ d ] += distance;
+		}
+	}
+
+	@Override
+	public void move( final int[] distance )
+	{
+		for ( int d = 0; d < n; ++d )
+		{
+			position[ d ] += distance[ d ];
+			currentOffset[ d ] += distance[ d ];
+		}
+	}
+
+	@Override
+	public void move( final long[] distance )
+	{
+		for ( int d = 0; d < n; ++d )
+		{
+			position[ d ] += distance[ d ];
+			currentOffset[ d ] += distance[ d ];
+		}
+	}
+
+	@Override
+	public void setPosition( final Localizable localizable )
+	{
+		for ( int d = 0; d < n; ++d )
+		{
+			final long distance = localizable.getLongPosition( d ) - position[ d ];
+			position[ d ] += distance;
+			currentOffset[ d ] += distance;
+		}
+	}
+
+	@Override
+	public void setPosition( final int[] pos )
+	{
+		for ( int d = 0; d < n; ++d )
+		{
+			final long distance = pos[ d ] - position[ d ];
+			position[ d ] += distance;
+			currentOffset[ d ] += distance;
+		}
+	}
+
+	@Override
+	public void setPosition( final long[] pos )
+	{
+		for ( int d = 0; d < n; ++d )
+		{
+			final long distance = pos[ d ] - position[ d ];
+			position[ d ] += distance;
+			currentOffset[ d ] += distance;
+		}
+	}
+
+	@Override
+	public void setPosition( final int pos, final int d )
+	{
+		final long distance = pos - position[ d ];
+		position[ d ] += distance;
+		currentOffset[ d ] += distance;
+	}
+
+	@Override
+	public void setPosition( final long pos, final int d )
+	{
+		final long distance = pos - position[ d ];
+		position[ d ] += distance;
+		currentOffset[ d ] += distance;
+	}
+
+	@Override
+	public double realMin( final int d )
+	{
+		return currentOffset[ d ] + initialMin[ d ];
+	}
+
+	@Override
+	public void realMin( final double[] min )
+	{
+		for ( int d = 0; d < n; ++d )
+			min[ d ] = currentOffset[ d ] + initialMin[ d ];
+	}
+
+	@Override
+	public void realMin( final RealPositionable min )
+	{
+		for ( int d = 0; d < n; ++d )
+			min.setPosition( currentOffset[ d ] + initialMin[ d ], d );
+	}
+
+	@Override
+	public double realMax( final int d )
+	{
+		return currentOffset[ d ] + initialMax[ d ];
+	}
+
+	@Override
+	public void realMax( final double[] max )
+	{
+		for ( int d = 0; d < n; ++d )
+			max[ d ] = currentOffset[ d ] + initialMax[ d ];
+	}
+
+	@Override
+	public void realMax( final RealPositionable max )
+	{
+		for ( int d = 0; d < n; ++d )
+			max.setPosition( currentOffset[ d ] + initialMax[ d ], d );
+	}
+
+	@Override
+	public long min( final int d )
+	{
+		return currentOffset[ d ] + initialMin[ d ];
+	}
+
+	@Override
+	public void min( final long[] min )
+	{
+		for ( int d = 0; d < n; ++d )
+			min[ d ] = currentOffset[ d ] + initialMin[ d ];
+	}
+
+	@Override
+	public void min( final Positionable min )
+	{
+		for ( int d = 0; d < n; ++d )
+			min.setPosition( currentOffset[ d ] + initialMin[ d ], d );
+	}
+
+	@Override
+	public long max( final int d )
+	{
+		return currentOffset[ d ] + initialMax[ d ];
+	}
+
+	@Override
+	public void max( final long[] max )
+	{
+		for ( int d = 0; d < n; ++d )
+			max[ d ] = currentOffset[ d ] + initialMax[ d ];
+	}
+
+	@Override
+	public void max( final Positionable max )
+	{
+		for ( int d = 0; d < n; ++d )
+			max.setPosition( currentOffset[ d ] + initialMax[ d ], d );
+	}
+
+	@Override
+	public void dimensions( final long[] dimensions )
+	{
+		for ( int d = 0; d < n; ++d )
+			dimensions[ d ] = initialMax[ d ] - initialMin[ d ] + 1;
+	}
+
+	@Override
+	public long dimension( final int d )
+	{
+		return initialMax[ d ] - initialMin[ d ] + 1;
+	}
+
+	private class Origin implements PositionableLocalizable
+	{
+		@Override
+		public int numDimensions()
+		{
+			return n;
+		}
+
+		@Override
+		public void localize( final float[] pos )
+		{
+			for ( int d = 0; d < n; ++d )
+				pos[ d ] = position[ d ] - currentOffset[ d ] - initialMin[ d ] ;
+		}
+
+		@Override
+		public void localize( final double[] pos )
+		{
+			for ( int d = 0; d < n; ++d )
+				pos[ d ] = position[ d ] - currentOffset[ d ] - initialMin[ d ];
+		}
+
+		@Override
+		public float getFloatPosition( final int d )
+		{
+			return position[ d ] - currentOffset[ d ] - initialMin[ d ];
+		}
+
+		@Override
+		public double getDoublePosition( final int d )
+		{
+			return position[ d ] - currentOffset[ d ] - initialMin[ d ];
+		}
+
+		@Override
+		public void localize( final int[] pos )
+		{
+			for ( int d = 0; d < n; ++d )
+				pos[ d ] = ( int ) ( position[ d ] - currentOffset[ d ] - initialMin[ d ] );
+		}
+
+		@Override
+		public void localize( final long[] pos )
+		{
+			for ( int d = 0; d < n; ++d )
+				pos[ d ] = position[ d ] - currentOffset[ d ] - initialMin[ d ];
+		}
+
+		@Override
+		public int getIntPosition( final int d )
+		{
+			return ( int ) ( position[ d ] - currentOffset[ d ] - initialMin[ d ] );
+		}
+
+		@Override
+		public long getLongPosition( final int d )
+		{
+			return position[ d ] - currentOffset[ d ] - initialMin[ d ];
+		}
+
+		@Override
+		public void fwd( final int d )
+		{
+			currentOffset[ d ]--;
+		}
+
+		@Override
+		public void bck( final int d )
+		{
+			currentOffset[ d ]++;
+		}
+
+		@Override
+		public void move( final int distance, final int d )
+		{
+			move( ( long ) distance, d );
+		}
+
+		@Override
+		public void move( final long distance, final int d )
+		{
+			currentOffset[ d ] -= distance;
+		}
+
+		@Override
+		public void move( final Localizable localizable )
+		{
+			for ( int d = 0; d < n; ++d )
+				move( localizable.getLongPosition( d ), d );
+		}
+
+		@Override
+		public void move( final int[] distance )
+		{
+			for ( int d = 0; d < n; ++d )
+				move( distance[ d ], d );
+		}
+
+		@Override
+		public void move( final long[] distance )
+		{
+			for ( int d = 0; d < n; ++d )
+				move( distance[ d ], d );
+		}
+
+		@Override
+		public void setPosition( final Localizable localizable )
+		{
+			for ( int d = 0; d < n; ++d )
+				setPosition( localizable.getLongPosition( d ), d );
+		}
+
+		@Override
+		public void setPosition( final int[] pos )
+		{
+			for ( int d = 0; d < n; ++d )
+				setPosition( pos[ d ], d );
+		}
+
+		@Override
+		public void setPosition( final long[] pos )
+		{
+			for ( int d = 0; d < n; ++d )
+				setPosition( pos[ d ], d );
+		}
+
+		@Override
+		public void setPosition( final int pos, final int d )
+		{
+			setPosition( ( long ) pos, d );
+		}
+
+		@Override
+		public void setPosition( final long pos, final int d )
+		{
+			final long distance = pos - position[ d ] + currentOffset[ d ] + initialMin[ d ];
+			move( distance, d );
+		}
+	}
+
+	@Override
+	public String toString()
+	{
+		final StringBuilder sb = new StringBuilder();
+
+		final String className = this.getClass().getSimpleName();
+		sb.append( className );
+
+		sb.append( " [(" );
+		for ( int d = 0; d < n; d++ )
+		{
+			sb.append( min( d ) );
+			if ( d < n - 1 )
+				sb.append( ", " );
+		}
+		sb.append( ") -- (" );
+		for ( int d = 0; d < n; d++ )
+		{
+			sb.append( max( d ) );
+			if ( d < n - 1 )
+				sb.append( ", " );
+		}
+		sb.append( ") = " );
+		for ( int d = 0; d < n; d++ )
+		{
+			sb.append( dimension( d ) );
+			if ( d < n - 1 )
+				sb.append( "x" );
+		}
+
+		sb.append( ", pos=(" );
+		for ( int d = 0; d < n; d++ )
+		{
+			sb.append( getLongPosition( d ) );
+			if ( d < n - 1 )
+				sb.append( ", " );
+		}
+		sb.append( "), origin(" );
+		for ( int d = 0; d < n; d++ )
+		{
+			sb.append( origin().getLongPosition( d ) );
+			if ( d < n - 1 )
+				sb.append( ", " );
+		}
+		sb.append( ")]" );
+
+		return sb.toString();
+	}
+}

--- a/src/main/java/net/imglib2/roi/util/PositionableLocalizable.java
+++ b/src/main/java/net/imglib2/roi/util/PositionableLocalizable.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util;
+
+import net.imglib2.Localizable;
+import net.imglib2.Positionable;
+
+/**
+ * Something that is {@link Positionable} and {@link Localizable}.
+ * <p>
+ * {@code PositionableLocalizable} is mainly intended as a return type. It
+ * should not be used as a argument type. {@code Localizable & Positionable}
+ * should be preferred where possible.
+ *
+ * @author Tobias Pietzsch
+ */
+public interface PositionableLocalizable extends Positionable, Localizable
+{}

--- a/src/main/java/net/imglib2/roi/util/PositionableWrappedIterableInterval.java
+++ b/src/main/java/net/imglib2/roi/util/PositionableWrappedIterableInterval.java
@@ -1,0 +1,169 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util;
+
+import java.util.Iterator;
+
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.roi.PositionableIterableInterval;
+
+/**
+ * Makes a {@link IterableInterval} {@code Positionable} by wrapping its cursors
+ * with an offset.
+ *
+ * @param <T>
+ *            pixel type of source
+ * @param <S>
+ *            source type
+ *
+ * @author Tobias Pietzsch
+ * @author Christian Dietz
+ */
+public class PositionableWrappedIterableInterval< T, S extends IterableInterval< T > >
+		extends PositionableInterval
+		implements PositionableIterableInterval< T >
+{
+	protected final S source;
+
+	public PositionableWrappedIterableInterval( final S source )
+	{
+		super( source );
+		this.source = source;
+	}
+
+	protected PositionableWrappedIterableInterval( final PositionableWrappedIterableInterval< T, S > other )
+	{
+		super( other );
+		this.source = other.source;
+	}
+
+	@Override
+	public long size()
+	{
+		return source.size();
+	}
+
+	@Override
+	public T firstElement()
+	{
+		return source.firstElement();
+	}
+
+	@Override
+	public Object iterationOrder()
+	{
+		return this;
+	}
+
+	@Override
+	public Iterator< T > iterator()
+	{
+		return cursor();
+	}
+
+	@Override
+	public Cursor< T > cursor()
+	{
+		return new PositionableIterableIntervalCursor( source.cursor() );
+	}
+
+	@Override
+	public Cursor< T > localizingCursor()
+	{
+		return new PositionableIterableIntervalCursor( source.localizingCursor() );
+	}
+
+	class PositionableIterableIntervalCursor extends OffsetLocalizable< Cursor< T > > implements Cursor< T >
+	{
+		public PositionableIterableIntervalCursor( final Cursor< T > cursor )
+		{
+			super( cursor, currentOffset );
+		}
+
+		@Override
+		public T get()
+		{
+			return source.get();
+		}
+
+		@Override
+		public void jumpFwd( final long steps )
+		{
+			source.jumpFwd( steps );
+		}
+
+		@Override
+		public void fwd()
+		{
+			source.fwd();
+		}
+
+		@Override
+		public void reset()
+		{
+			source.reset();
+		}
+
+		@Override
+		public boolean hasNext()
+		{
+			return source.hasNext();
+		}
+
+		@Override
+		public T next()
+		{
+			return source.next();
+		}
+
+		@Override
+		public PositionableIterableIntervalCursor copy()
+		{
+			return new PositionableIterableIntervalCursor( source.copyCursor() );
+		}
+
+		@Override
+		public PositionableIterableIntervalCursor copyCursor()
+		{
+			return copy();
+		}
+	}
+
+	@Override
+	public PositionableWrappedIterableInterval< T, S > copy()
+	{
+		return new PositionableWrappedIterableInterval<>( this );
+	}
+}

--- a/src/main/java/net/imglib2/roi/util/PositionableWrappedIterableRegion.java
+++ b/src/main/java/net/imglib2/roi/util/PositionableWrappedIterableRegion.java
@@ -1,0 +1,102 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util;
+
+import net.imglib2.Interval;
+import net.imglib2.RandomAccess;
+import net.imglib2.roi.IterableRegion;
+import net.imglib2.roi.PositionableIterableRegion;
+import net.imglib2.type.BooleanType;
+import net.imglib2.util.Intervals;
+
+/**
+ * Makes a {@link IterableRegion} {@code Positionable} by wrapping its accessors
+ * with an offset.
+ *
+ * @param <T>
+ *            pixel type of source
+ */
+public class PositionableWrappedIterableRegion< T extends BooleanType< T > >
+		extends PositionableWrappedIterableInterval< Void, IterableRegion< T > >
+		implements PositionableIterableRegion< T >
+{
+	public PositionableWrappedIterableRegion( final IterableRegion< T > source )
+	{
+		super( source );
+	}
+
+	@Override
+	public RandomAccess< T > randomAccess()
+	{
+		return new RA( source.randomAccess(), currentOffset );
+	}
+
+	@Override
+	public RandomAccess< T > randomAccess( final Interval interval )
+	{
+		return new RA( source.randomAccess( Intervals.translate( interval, currentOffset ) ), currentOffset );
+	}
+
+	class RA extends OffsetPositionableLocalizable< RandomAccess< T > > implements RandomAccess< T >
+	{
+		public RA( final RandomAccess< T > source, final long[] offset )
+		{
+			super( source, offset );
+		}
+
+		@Override
+		public T get()
+		{
+			return source.get();
+		}
+
+		@Override
+		public RA copy()
+		{
+			return new RA( source.copyRandomAccess(), offset );
+		}
+
+		@Override
+		public RA copyRandomAccess()
+		{
+			return copy();
+		}
+	}
+
+	@Override
+	public PositionableWrappedIterableRegion< T > copy()
+	{
+		return new PositionableWrappedIterableRegion<>( this );
+	}
+}

--- a/src/main/java/net/imglib2/roi/util/RandomAccessibleRegionCursor.java
+++ b/src/main/java/net/imglib2/roi/util/RandomAccessibleRegionCursor.java
@@ -39,6 +39,7 @@ import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.BooleanType;
 
+@Deprecated
 public class RandomAccessibleRegionCursor< T extends BooleanType< T > > extends AbstractWrappedInterval< RandomAccessibleInterval< T > > implements Cursor< Void >
 {
 	private final RandomAccess< T > randomAccess;

--- a/src/main/java/net/imglib2/roi/util/TrueCursor.java
+++ b/src/main/java/net/imglib2/roi/util/TrueCursor.java
@@ -1,0 +1,126 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util;
+
+import net.imglib2.AbstractWrappedLocalizable;
+import net.imglib2.Cursor;
+import net.imglib2.type.BooleanType;
+
+/**
+ * A {@code Cursor<Void>} that iterates only the {@code true} pixels of a source
+ * {@code Cursor<BooleanType>}.
+ *
+ * @author Tobias Pietzsch
+ */
+class TrueCursor< T extends BooleanType< T > >
+		extends AbstractWrappedLocalizable< Cursor< T > >
+		implements Cursor< Void >
+{
+	private long index;
+
+	private final long maxIndex;
+
+	private final boolean empty;
+
+	public TrueCursor( final Cursor< T > cursor, final long size )
+	{
+		super( cursor );
+		maxIndex = size;
+		empty = size == 0;
+		reset();
+	}
+
+	protected TrueCursor( final TrueCursor< T > other )
+	{
+		super( other.source.copyCursor() );
+		index = other.index;
+		empty = other.empty;
+		maxIndex = other.maxIndex;
+	}
+
+	@Override
+	public Void get()
+	{
+		return null;
+	}
+
+	@Override
+	public void jumpFwd( final long steps )
+	{
+		for ( long i = 0; i < steps; ++i )
+			fwd();
+	}
+
+	@Override
+	public void fwd()
+	{
+		if ( empty )
+			return;
+		while ( !source.next().get() )
+			;
+		++index;
+	}
+
+	@Override
+	public void reset()
+	{
+		index = 0;
+		source.reset();
+	}
+
+	@Override
+	public boolean hasNext()
+	{
+		return index < maxIndex;
+	}
+
+	@Override
+	public Void next()
+	{
+		fwd();
+		return get();
+	}
+
+	@Override
+	public TrueCursor< T > copy()
+	{
+		return new TrueCursor<>( this );
+	}
+
+	@Override
+	public TrueCursor< T > copyCursor()
+	{
+		return copy();
+	}
+}

--- a/src/main/java/net/imglib2/roi/util/iterationcode/IterationCode.java
+++ b/src/main/java/net/imglib2/roi/util/iterationcode/IterationCode.java
@@ -57,7 +57,7 @@ import net.imglib2.EuclideanSpace;
  * [p0max, p1, ..., pn] are contained in the bitmask, where p1, ..., pn are the
  * current starting position in dimensions 1, ..., n.
  *
- * [dim, p1, ..., p(-dim)] modifies dimensions p1, ..., p(-dim) of the current
+ * [-dim, p1, ..., p(dim)] modifies dimensions p1, ..., p(dim) of the current
  * starting position.
  * }
  * </pre>

--- a/src/main/java/net/imglib2/roi/util/iterationcode/IterationCodeCursor.java
+++ b/src/main/java/net/imglib2/roi/util/iterationcode/IterationCodeCursor.java
@@ -1,0 +1,120 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util.iterationcode;
+
+import net.imglib2.AbstractLocalizable;
+import net.imglib2.Cursor;
+import net.imglib2.Point;
+
+import gnu.trove.list.array.TIntArrayList;
+
+/**
+ * A {@code Cursor<Void>} that visits all positions in the bitmask encoded by a
+ * given {@link IterationCode}.
+ * <p>
+ * It is constructed with a {@code long[]} offset which is not copied, so it can
+ * be used to shift the bitmask and reuse this cursor.
+ *
+ * @author Tobias Pietzsch
+ */
+public class IterationCodeCursor extends AbstractLocalizable implements Cursor< Void >
+{
+	private final IterationCodeIterator< Point > iter;
+
+	public IterationCodeCursor( final IterationCode iterationCode, final long[] offset )
+	{
+		this( iterationCode.getItcode(), offset );
+	}
+
+	public IterationCodeCursor( final TIntArrayList itcode, final long[] offset )
+	{
+		super( offset.length );
+		iter = new IterationCodeIterator<>( itcode, offset, Point.wrap( position ) );
+	}
+
+	protected IterationCodeCursor( final IterationCodeCursor c )
+	{
+		super( c.position );
+		iter = new IterationCodeIterator<>( c.iter, Point.wrap( position ) );
+	}
+
+	@Override
+	public Void get()
+	{
+		return null;
+	}
+
+	@Override
+	public void jumpFwd( final long steps )
+	{
+		iter.jumpFwd( steps );
+	}
+
+	@Override
+	public void fwd()
+	{
+		iter.fwd();
+	}
+
+	@Override
+	public void reset()
+	{
+		iter.reset();
+	}
+
+	@Override
+	public boolean hasNext()
+	{
+		return iter.hasNext();
+	}
+
+	@Override
+	public Void next()
+	{
+		fwd();
+		return null;
+	}
+
+	@Override
+	public IterationCodeCursor copy()
+	{
+		return new IterationCodeCursor( this );
+	}
+
+	@Override
+	public IterationCodeCursor copyCursor()
+	{
+		return copy();
+	}
+}

--- a/src/main/java/net/imglib2/roi/util/iterationcode/IterationCodeListCursor.java
+++ b/src/main/java/net/imglib2/roi/util/iterationcode/IterationCodeListCursor.java
@@ -1,0 +1,120 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util.iterationcode;
+
+import java.util.ArrayList;
+
+import net.imglib2.AbstractLocalizable;
+import net.imglib2.Cursor;
+import net.imglib2.Point;
+import net.imglib2.roi.labeling.LabelRegion;
+
+import gnu.trove.list.array.TIntArrayList;
+
+/**
+ * A {@code Cursor<Void>} that visits all positions in the bitmask encoded by a
+ * given list of {@link IterationCode}s. (This is used to iterate a
+ * {@link LabelRegion} which is the union of fragments which are encoded by
+ * {@link IterationCode}s.)
+ * <p>
+ * It is constructed with a {@code long[]} offset which is not copied, so it can
+ * be used to shift the bitmask and reuse this cursor.
+ *
+ * @author Tobias Pietzsch
+ */
+public class IterationCodeListCursor extends AbstractLocalizable implements Cursor< Void >
+{
+	private final IterationCodeListIterator< Point > iter;
+
+	public IterationCodeListCursor( final ArrayList< TIntArrayList > itcodesList, final long[] offset )
+	{
+		super( offset.length );
+		iter = new IterationCodeListIterator<>( itcodesList, offset, Point.wrap( position ) );
+	}
+
+	protected IterationCodeListCursor( final IterationCodeListCursor c )
+	{
+		super( c.position );
+		iter = new IterationCodeListIterator<>( c.iter, Point.wrap( position ) );
+	}
+
+	@Override
+	public Void get()
+	{
+		return null;
+	}
+
+	@Override
+	public void jumpFwd( final long steps )
+	{
+		iter.jumpFwd( steps );
+	}
+
+	@Override
+	public void fwd()
+	{
+		iter.fwd();
+	}
+
+	@Override
+	public void reset()
+	{
+		iter.reset();
+	}
+
+	@Override
+	public boolean hasNext()
+	{
+		return iter.hasNext();
+	}
+
+	@Override
+	public Void next()
+	{
+		fwd();
+		return null;
+	}
+
+	@Override
+	public IterationCodeListCursor copy()
+	{
+		return new IterationCodeListCursor( this );
+	}
+
+	@Override
+	public IterationCodeListCursor copyCursor()
+	{
+		return copy();
+	}
+}

--- a/src/test/java/net/imglib2/roi/util/IterableRandomAccessibleRegionBenchmarkTest.java
+++ b/src/test/java/net/imglib2/roi/util/IterableRandomAccessibleRegionBenchmarkTest.java
@@ -31,13 +31,15 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package net.imglib2.roi;
+package net.imglib2.roi.util;
 
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
 import java.util.Random;
 
+import net.imglib2.roi.IterableRegion;
+import net.imglib2.roi.Regions;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/net/imglib2/roi/util/IterableRandomAccessibleRegionBenchmarkTest.java
+++ b/src/test/java/net/imglib2/roi/util/IterableRandomAccessibleRegionBenchmarkTest.java
@@ -60,6 +60,7 @@ import net.imglib2.type.logic.BitType;
  * @author Alison Walter
  * @author Tobias Pietzsch
  */
+@Deprecated
 public class IterableRandomAccessibleRegionBenchmarkTest
 {
 

--- a/src/test/java/net/imglib2/roi/util/IterableRandomAccessibleRegionTest.java
+++ b/src/test/java/net/imglib2/roi/util/IterableRandomAccessibleRegionTest.java
@@ -32,7 +32,7 @@
  * #L%
  */
 
-package net.imglib2.roi;
+package net.imglib2.roi.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -45,6 +45,8 @@ import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.roi.IterableRegion;
+import net.imglib2.roi.Regions;
 import net.imglib2.roi.util.IterableRandomAccessibleRegion;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.util.ConstantUtils;

--- a/src/test/java/net/imglib2/roi/util/IterableRegionOnBooleanRAIBenchmark.java
+++ b/src/test/java/net/imglib2/roi/util/IterableRegionOnBooleanRAIBenchmark.java
@@ -1,0 +1,139 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util;
+
+import java.util.Random;
+import net.imglib2.Cursor;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.BooleanArray;
+import net.imglib2.roi.Regions;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+/**
+ * Benchmark comparing cursors on IterableRandomAccessibleRegion and IterableRegionOnBooleanRAI.
+ *
+ * @author Tobias Pietzsch
+ */
+public class IterableRegionOnBooleanRAIBenchmark
+{
+	@State( Scope.Benchmark )
+	public static class MyState
+	{
+		IterableRandomAccessibleRegion< NativeBoolType > irOld;
+		IterableRegionOnBooleanRAI< NativeBoolType > ir;
+		IterableRandomAccessibleRegion< NativeBoolType > irViewOld;
+		IterableRegionOnBooleanRAI< NativeBoolType > irView;
+
+		@Setup( Level.Trial )
+		public void doSetup()
+		{
+			final ArrayImg< NativeBoolType, BooleanArray > img = ArrayImgs.booleans( 100, 100, 100 );
+			final Random rand = new Random( 12 );
+			img.forEach( t -> t.set( rand.nextDouble() < 0.1 ) );
+
+			final long countTrue = Regions.countTrue( img );
+
+			irOld = new IterableRandomAccessibleRegion<>( img, countTrue );
+			ir = new IterableRegionOnBooleanRAI<>( img, countTrue );
+			irViewOld = new IterableRandomAccessibleRegion<>( Views.interval( img, Intervals.expand( img, -1 ) ), countTrue );
+			irView = new IterableRegionOnBooleanRAI<>( Views.interval( img, Intervals.expand( img, -1 ) ), countTrue );
+		}
+	}
+
+	@Benchmark
+	public void testIterableRandomAccessibleRegion( MyState state )
+	{
+		final Cursor< Void > c = state.irOld.cursor();
+		while ( c.hasNext() )
+		{
+			c.next();
+		}
+	}
+
+	@Benchmark
+	public void testIterableRegionOnBooleanRAI( MyState state )
+	{
+		final Cursor< Void > c = state.ir.cursor();
+		while ( c.hasNext() )
+		{
+			c.next();
+		}
+	}
+
+	@Benchmark
+	public void testIterableRandomAccessibleRegionForNonIterableView( MyState state )
+	{
+		final Cursor< Void > c = state.irViewOld.cursor();
+		while ( c.hasNext() )
+		{
+			c.next();
+		}
+	}
+
+	@Benchmark
+	public void testIterableRegionOnBooleanRAIForNonIterableView( MyState state )
+	{
+		final Cursor< Void > c = state.irView.cursor();
+		while ( c.hasNext() )
+		{
+			c.next();
+		}
+	}
+
+	public static void main( String[] args ) throws RunnerException
+	{
+		Options opt = new OptionsBuilder()
+				.include( IterableRegionOnBooleanRAIBenchmark.class.getSimpleName() )
+				.forks( 1 )
+				.warmupIterations( 8 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 200 ) )
+				.measurementTime( TimeValue.milliseconds( 200 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+}

--- a/src/test/java/net/imglib2/roi/util/IterableRegionOnBooleanRAITest.java
+++ b/src/test/java/net/imglib2/roi/util/IterableRegionOnBooleanRAITest.java
@@ -34,12 +34,8 @@
 
 package net.imglib2.roi.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.NoSuchElementException;
 import java.util.Random;
-
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessibleInterval;
@@ -47,14 +43,15 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.roi.IterableRegion;
 import net.imglib2.roi.Regions;
-import net.imglib2.roi.util.IterableRandomAccessibleRegion;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.util.ConstantUtils;
-
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@link IterableRandomAccessibleRegion}.
@@ -62,7 +59,7 @@ import org.junit.rules.ExpectedException;
  * @author Alison Walter
  *
  */
-public class IterableRandomAccessibleRegionTest
+public class IterableRegionOnBooleanRAITest
 {
 
 	private static IterableRegion< BitType > empty;

--- a/src/test/java/net/imglib2/roi/util/PositionableIntervalTest.java
+++ b/src/test/java/net/imglib2/roi/util/PositionableIntervalTest.java
@@ -1,0 +1,138 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.util;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.util.Intervals;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PositionableIntervalTest
+{
+	@Test
+	public void testConstruction()
+	{
+		final long[] min = new long[] { 1, 2, 3 };
+		final long[] max = new long[] { 4, 5, 6 };
+
+		final PositionableInterval interval = new PositionableInterval( new FinalInterval( min, max ) );
+
+		Assert.assertEquals( interval.numDimensions(), min.length );
+		for ( int d = 0; d < interval.numDimensions(); ++d )
+		{
+			Assert.assertEquals( min[ d ], interval.min( d ) );
+			Assert.assertEquals( max[ d ], interval.max( d ) );
+			Assert.assertEquals( 0, interval.getLongPosition( d ) );
+		}
+	}
+
+	@Test
+	public void testMove()
+	{
+		final long[] min = new long[] { 1, 2, 3 };
+		final long[] max = new long[] { 4, 5, 6 };
+		final long[] move = new long[] { 12, -32, 0 };
+
+		final PositionableInterval interval = new PositionableInterval( new FinalInterval( min, max ) );
+		interval.move( move );
+
+		for ( int d = 0; d < interval.numDimensions(); ++d )
+		{
+			Assert.assertEquals( min[ d ] + move[ d ], interval.min( d ) );
+			Assert.assertEquals( max[ d ] + move[ d ], interval.max( d ) );
+			Assert.assertEquals( move[ d ], interval.getLongPosition( d ) );
+		}
+	}
+
+	@Test
+	public void testSetPosition()
+	{
+		final long[] min = new long[] { 1, 2, 3 };
+		final long[] max = new long[] { 4, 5, 6 };
+		final long[] pos = new long[] { 12, -32, 0 };
+
+		final PositionableInterval interval = new PositionableInterval( new FinalInterval( min, max ) );
+		interval.setPosition( pos );
+
+		for ( int d = 0; d < interval.numDimensions(); ++d )
+		{
+			Assert.assertEquals( min[ d ] + pos[ d ], interval.min( d ) );
+			Assert.assertEquals( max[ d ] + pos[ d ], interval.max( d ) );
+			Assert.assertEquals( pos[ d ], interval.getLongPosition( d ) );
+		}
+	}
+
+	@Test
+	public void testOrigin()
+	{
+		final long[] min = new long[] { 1, 2, 3 };
+		final long[] max = new long[] { 4, 5, 6 };
+
+		final PositionableInterval interval = new PositionableInterval( new FinalInterval( min, max ) );
+
+		for ( int d = 0; d < interval.numDimensions(); ++d )
+		{
+			Assert.assertEquals( -min[ d ], interval.origin().getLongPosition( d ) );
+		}
+	}
+
+	@Test
+	public void testSetOrigin()
+	{
+		final PositionableInterval interval = new PositionableInterval( Intervals.createMinSize( 0, 0, 9, 9 ) );
+		interval.origin().setPosition( new int[] { 4, 4 } );
+		for ( int d = 0; d < 2; ++d )
+		{
+			Assert.assertEquals( -4, interval.min( d ) );
+			Assert.assertEquals( 4, interval.max( d ) );
+			Assert.assertEquals( 0, interval.getLongPosition( d ) );
+			Assert.assertEquals( 4, interval.origin().getLongPosition( d ) );
+		}
+	}
+
+	@Test
+	public void testMoveOrigin()
+	{
+		final PositionableInterval interval = new PositionableInterval( Intervals.createMinSize( 0, 0, 9, 9 ) );
+		interval.origin().move( new int[] { 4, 4 } );
+		for ( int d = 0; d < 2; ++d )
+		{
+			Assert.assertEquals( -4, interval.min( d ) );
+			Assert.assertEquals( 4, interval.max( d ) );
+			Assert.assertEquals( 0, interval.getLongPosition( d ) );
+			Assert.assertEquals( 4, interval.origin().getLongPosition( d ) );
+		}
+	}
+}


### PR DESCRIPTION
Adds a new `Regions.positionable()` static method that takes any `RandomAccessibleInterval<BooleanType>` and makes it an `PositionableIterableRegion`.

The `PositionableIterableRegion` is `Positionable`. It can be moved around, for example to `Regions.sample()` an image with the region positioned on different locations.

The `PositionableIterableRegion` has a `PosionableLocalizable origin()` that can be used to change the center of the region. The origin is the relative offset of the position to the minimum. For example if a positionable (bitmask) region is made from a `BitType` image with a circular pattern, then it is more natural if the region position refers to the center of the pattern instead of the upper left corner of the `BitType` image. This can be achieved by positioning the origin.
Assume a region is created from a 9x9 bitmask. The region initially has `min=(0,0), max=(8,8), position=(0,0)`. Because both `position` and `min` are `(0,0)`, initially `origin=(0,0)`. Now assume the origin is moved to the center of the bitmask using `origin().setPosition(new int[]{4,4})`. After this, `min=(-4,-4), max=(4,4), position=(0,0)`, and `origin=(4,4)`. `region.setPosition()` can now be used to put the center of the mask on some pixel. Then `Regions.sample()` can be used to overlay the region on a target image, and iterate the target pixels under the positioned region.

(This is part one of a framework that will allow to do `Neighborhoods`-like operations using arbitrary masks. Ultimately, the current `Neighborhoods` will be integrated into the same framework.)