### PR TITLE
Use UnsignedIntType instead of IntType for labelings

### DIFF
--- a/src/test/java/net/imglib2/roi/labeling/ImgLabelingTest.java
+++ b/src/test/java/net/imglib2/roi/labeling/ImgLabelingTest.java
@@ -3,7 +3,8 @@ package net.imglib2.roi.labeling;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
-import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -22,12 +23,12 @@ public class ImgLabelingTest {
 	@Test
 	public void testCreateFromImageAndLabelSets() {
 		// setup
-		Img<IntType> image = ArrayImgs.ints(new int[]{1, 0, 2}, 3);
+		Img<UnsignedIntType> image = ArrayImgs.unsignedInts(new int[]{1, 0, 2}, 3);
 		String[] values = {"A", "B"};
 		String[] valuesB = {"Hello", "World"};
 		List<Set<String>> labelSets = Arrays.asList(asSet(), asSet(values), asSet(valuesB));
 		// process
-		ImgLabeling<String, IntType> labeling = ImgLabeling.fromImageAndLabelSets(image, labelSets);
+		ImgLabeling<String, UnsignedIntType> labeling = ImgLabeling.fromImageAndLabelSets(image, labelSets);
 		// test
 		RandomAccess<LabelingType<String>> ra = labeling.randomAccess();
 		ra.setPosition(new long[]{0});
@@ -41,10 +42,10 @@ public class ImgLabelingTest {
 	@Test
 	public void testCreateFromImageAndLabels() {
 		// setup
-		Img<IntType> image = ArrayImgs.ints(new int[]{3}, 1);
+		Img<UnsignedIntType> image = ArrayImgs.unsignedInts(new int[]{3}, 1);
 		List<String> labels = Arrays.asList("a", "b", "c", "d", "e", "f", "g");
 		// process
-		ImgLabeling<String, IntType> labeling = ImgLabeling.fromImageAndLabels(image, labels);
+		ImgLabeling<String, UnsignedIntType> labeling = ImgLabeling.fromImageAndLabels(image, labels);
 		// test
 		RandomAccess<LabelingType<String>> ra = labeling.randomAccess();
 		ra.setPosition(new long[]{0});
@@ -55,9 +56,9 @@ public class ImgLabelingTest {
 	public void testModifyCreatedImgLabeling() {
 		// setup
 		int[] data = {2};
-		Img<IntType> image = ArrayImgs.ints(data, 1);
+		Img<UnsignedIntType> image = ArrayImgs.unsignedInts(data, 1);
 		List<Set<String>> labelSets = Arrays.asList(asSet(), asSet("1","2"), asSet("1"));
-		ImgLabeling<String, IntType> labeling = ImgLabeling.fromImageAndLabelSets(image, labelSets);
+		ImgLabeling<String, UnsignedIntType> labeling = ImgLabeling.fromImageAndLabelSets(image, labelSets);
 		RandomAccess<LabelingType<String>> ra = labeling.randomAccess();
 		ra.setPosition(new long[]{0});
 		// process
@@ -69,8 +70,8 @@ public class ImgLabelingTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testCreatedImgLabelingRepeatingLabel() {
-		Img<IntType> image = ArrayImgs.ints(new int[]{2}, 1);
-		ImgLabeling<String, IntType> labeling = ImgLabeling.fromImageAndLabels(image, Arrays.asList("1", "1"));
+		Img<UnsignedIntType> image = ArrayImgs.unsignedInts(new int[]{2}, 1);
+		ImgLabeling<String, UnsignedIntType> labeling = ImgLabeling.fromImageAndLabels(image, Arrays.asList("1", "1"));
 	}
 
 	private <T> Set<T> asSet(T... values) {


### PR DESCRIPTION
Since labels are auto-generated starting from 1, using `IntType` wastes half of the dynamic range.

Tests should be able to serve as example code. Let's not encourage the use of signed data types for label images.
