### PR TITLE
Simplify quantification of overlapping labels

### DIFF
--- a/src/main/java/net/imglib2/roi/labeling/LabelRegions.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelRegions.java
@@ -72,7 +72,7 @@ public class LabelRegions< T > extends AbstractEuclideanSpace implements Iterabl
 
 	private final LabelingType< T > type;
 
-	private final ArrayList< FragmentProperties > indexToFragmentProperties;
+	protected final ArrayList< FragmentProperties > indexToFragmentProperties;
 
 	/**
 	 * Maps labels to {@link LabelRegionProperties} for all currently non-empty labels in the labeling.

--- a/src/main/java/net/imglib2/roi/labeling/OverlappingLabels.java
+++ b/src/main/java/net/imglib2/roi/labeling/OverlappingLabels.java
@@ -1,0 +1,194 @@
+package net.imglib2.roi.labeling;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Util;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+public class OverlappingLabels< T extends Comparable< T > >
+{
+
+	private Img< UnsignedIntType > overlapMatrix;
+
+	private List< T > labelList;
+
+	private Img< LongType > labelSizeImg;
+
+	private Img< DoubleType > relativeOverlapMatrix;
+
+	public OverlappingLabels( RandomAccessibleInterval< LabelingType< T > > labeling )
+	{
+
+		FragmentLabelRegions labelRegions = new FragmentLabelRegions( labeling );
+
+		// List of existing labels
+		// NB: this triggers labelRegions computation
+		labelList = new ArrayList<>( labelRegions.getExistingLabels() );
+		Collections.sort( labelList );
+
+		// Create 2D matrix image
+		FinalInterval matrixDims = new FinalInterval( labelList.size(), labelList.size() );
+		overlapMatrix = Util.getSuitableImgFactory( matrixDims, new UnsignedIntType() ).create( matrixDims );
+
+		// Sum up sizes of single fragments
+		RandomAccess< UnsignedIntType > randomAccess = overlapMatrix.randomAccess();
+		UnsignedIntType sizeType = new UnsignedIntType();
+		LabelingMapping< T > labelingMapping = Labelings.getLabelingMapping( labeling );
+		for ( int i = 0; i < labelingMapping.numSets(); i++ )
+		{
+			Set< T > currentLabels = labelingMapping.labelsAtIndex( i );
+			long size = labelRegions.getFragmentSizeForIndex( i );
+			if ( size > 0 )
+			{
+				sizeType.set( size );
+				for ( T a : currentLabels )
+				{
+					randomAccess.setPosition( labelList.indexOf( a ), 0 );
+					for ( T b : currentLabels )
+					{
+						randomAccess.setPosition( labelList.indexOf( b ), 1 );
+						randomAccess.get().add( sizeType );
+					}
+				}
+			}
+		}
+
+		labelSizeImg = ArrayImgs.longs( labelList.size() );
+		Cursor< LongType > cursor = labelSizeImg.localizingCursor();
+		while ( cursor.hasNext() )
+		{
+			cursor.next().set( labelRegions.getLabelRegion( labelList.get( cursor.getIntPosition( 0 ) ) ).size() );
+		}
+
+		relativeOverlapMatrix = Util.getSuitableImgFactory( matrixDims, new DoubleType() ).create( matrixDims );
+		IntervalView< LongType > divisor = Views.addDimension( labelSizeImg, 0, labelList.size() - 1 );
+
+		LoopBuilder.setImages( overlapMatrix, divisor, relativeOverlapMatrix ).forEachPixel( ( a, b, c ) -> c.set( ( double ) a.get() / b.get() ) );
+	}
+
+	/**
+	 * Get the confusion/co-occurrence matrix.
+	 * 
+	 * Values indicate the number of pixels that are in common between the label
+	 * at position x and the label at position y. For the mapping of dimension
+	 * indices to labels, see {@link OverlappingLabels#getIndexedLabels()}.
+	 * 
+	 * @return the co-occurrence matrix
+	 */
+	public RandomAccessibleInterval< UnsignedIntType > getMatrix()
+	{
+		return overlapMatrix;
+	}
+
+	/**
+	 * Get the normalized directional confusion matrix.
+	 * 
+	 * Values indicate the proportion of the label at position x that is
+	 * co-occurring with the label at position y. For the mapping of dimension
+	 * indices to labels, see {@link OverlappingLabels#getIndexedLabels()}.
+	 * 
+	 * @return the normalized co-occurrence matrix
+	 */
+	public RandomAccessibleInterval< DoubleType > getNormalizedMatrix()
+	{
+		return relativeOverlapMatrix;
+	}
+
+	/**
+	 * Get the list of labels for this confusion matrix.
+	 * 
+	 * @return the list of labels in order of the matrix indices
+	 */
+	public List< T > getIndexedLabels()
+	{
+		return labelList;
+	}
+
+	/**
+	 * The number of pixels overlapping between two labels.
+	 * 
+	 * @param label1
+	 *            The first label
+	 * @param label2
+	 *            The second label
+	 * @return the size of the overlapping region (in pixels)
+	 */
+	public long getPixelOverlap( T label1, T label2 )
+	{
+		return getPixelOverlapForIndex( labelList.indexOf( label1 ), labelList.indexOf( label2 ) );
+	}
+
+	/**
+	 * The number of pixels overlapping between two labels at the specified
+	 * indices.
+	 * 
+	 * @param index1
+	 *            The index of the first label
+	 * @param index2
+	 *            The index of the second label
+	 * @return the size of the overlapping region (in pixels)
+	 */
+	public long getPixelOverlapForIndex( int index1, int index2 )
+	{
+		return overlapMatrix.getAt( index1, index2 ).get();
+	}
+
+	/**
+	 * The fraction of {@code ofLabel} that overlaps with
+	 * {@code overlappingLabel}.
+	 * 
+	 * If {@code ofLabel} has size 2 and {@code overlappingLabel} has size 100,
+	 * and they overlap by 1 pixel, the resulting fraction is 0.5
+	 * 
+	 * @param ofLabel
+	 * @param overlappingLabel
+	 * @return the overlapping fraction
+	 */
+	public double getPartialOverlap( T ofLabel, T overlappingLabel )
+	{
+		return getPartialOverlapForIndex( labelList.indexOf( ofLabel ), labelList.indexOf( overlappingLabel ) );
+	}
+
+	/**
+	 * The fraction of the label at {@code ofLabelIndex} that overlaps with the
+	 * label at {@code overlappingLabelIndex}.
+	 * 
+	 * See {@link OverlappingLabels#getPartialOverlap(Comparable, Comparable)}.
+	 * 
+	 * @param ofLabelIndex
+	 * @param overlappingLabelIndex
+	 * @return the overlapping fraction
+	 */
+	public double getPartialOverlapForIndex( int ofLabelIndex, int overlappingLabelIndex )
+	{
+		return relativeOverlapMatrix.getAt( ofLabelIndex, overlappingLabelIndex ).get();
+	}
+
+	private class FragmentLabelRegions extends LabelRegions< T >
+	{
+
+		public FragmentLabelRegions( RandomAccessibleInterval< LabelingType< T > > labeling )
+		{
+			super( labeling );
+		}
+
+		public long getFragmentSizeForIndex( int index )
+		{
+			return indexToFragmentProperties.get( index ).getSize();
+		}
+	}
+}

--- a/src/test/java/net/imglib2/roi/labeling/OverlappingLabelsTest.java
+++ b/src/test/java/net/imglib2/roi/labeling/OverlappingLabelsTest.java
@@ -1,0 +1,97 @@
+package net.imglib2.roi.labeling;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.Test;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+public class OverlappingLabelsTest
+{
+
+	@Test
+	public void testOverlappingLabels()
+	{
+		ImgLabeling< Integer, UnsignedByteType > labeling = createTestLabeling();
+		OverlappingLabels< Integer > overlap = new OverlappingLabels<>( labeling );
+
+		List< Integer > labels = overlap.getIndexedLabels();
+		assertArrayEquals( new Integer[] { 1, 2, 3 }, labels.toArray() );
+
+		RandomAccessibleInterval< UnsignedIntType > matrix = overlap.getMatrix();
+		assertEquals( 3, matrix.dimension( 0 ) );
+		assertEquals( 3, matrix.dimension( 1 ) );
+		RandomAccess< UnsignedIntType > ra = matrix.randomAccess();
+		ra.setPosition( new int[] { 0, 0 } );
+		assertEquals( 4, ra.get().get() );
+		ra.setPosition( new int[] { 1, 0 } );
+		assertEquals( 1, ra.get().get() );
+		ra.setPosition( new int[] { 2, 0 } );
+		assertEquals( 2, ra.get().get() );
+		ra.setPosition( new int[] { 0, 1 } );
+		assertEquals( 1, ra.get().get() );
+		ra.setPosition( new int[] { 1, 1 } );
+		assertEquals( 2, ra.get().get() );
+		ra.setPosition( new int[] { 2, 1 } );
+		assertEquals( 1, ra.get().get() );
+		ra.setPosition( new int[] { 0, 2 } );
+		assertEquals( 2, ra.get().get() );
+		ra.setPosition( new int[] { 1, 2 } );
+		assertEquals( 1, ra.get().get() );
+		ra.setPosition( new int[] { 2, 2 } );
+		assertEquals( 4, ra.get().get() );
+
+		RandomAccessibleInterval< DoubleType > normalizedMatrix = overlap.getNormalizedMatrix();
+		RandomAccess< DoubleType > nra = normalizedMatrix.randomAccess();
+		nra.setPosition( new int[] { 0, 0 } );
+		assertEquals( 1.0, nra.get().get(), 0.0 );
+		nra.setPosition( new int[] { 1, 0 } );
+		assertEquals( 0.5, nra.get().get(), 0.0 );
+		nra.setPosition( new int[] { 2, 0 } );
+		assertEquals( 0.5, nra.get().get(), 0.0 );
+		nra.setPosition( new int[] { 0, 1 } );
+		assertEquals( 0.25, nra.get().get(), 0.0 );
+		nra.setPosition( new int[] { 1, 1 } );
+		assertEquals( 1.0, nra.get().get(), 0.0 );
+		nra.setPosition( new int[] { 2, 1 } );
+		assertEquals( 0.25, nra.get().get(), 0.0 );
+		nra.setPosition( new int[] { 0, 2 } );
+		assertEquals( 0.5, nra.get().get(), 0.0 );
+		nra.setPosition( new int[] { 1, 2 } );
+		assertEquals( 0.5, nra.get().get(), 0.0 );
+		nra.setPosition( new int[] { 2, 2 } );
+		assertEquals( 1.0, nra.get().get(), 0.0 );
+
+		assertEquals( 2, overlap.getPixelOverlap( 1, 3 ) );
+		assertEquals( 2, overlap.getPixelOverlapForIndex( 0, 2 ) );
+
+		assertEquals( 0.50, overlap.getPartialOverlap( 2, 3 ), 0.0 );
+		assertEquals( 0.25, overlap.getPartialOverlap( 3, 2 ), 0.0 );
+		assertEquals( 0.50, overlap.getPartialOverlapForIndex( 1, 2 ), 0.0 );
+		assertEquals( 0.25, overlap.getPartialOverlapForIndex( 2, 1 ), 0.0 );
+	}
+
+	private ImgLabeling< Integer, UnsignedByteType > createTestLabeling()
+	{
+		Img< UnsignedByteType > indexImg = ArrayImgs.unsignedBytes( new byte[] { 0, 1, 1, 2, 5, 4, 0, 3, 3 }, 3, 3 );
+		List< Set< Integer > > mapping = Arrays.asList( asSet(), asSet( 1 ), asSet( 2 ), asSet( 3 ), asSet( 1, 3 ), asSet( 1, 2, 3 ) );
+		return ImgLabeling.fromImageAndLabelSets( indexImg, mapping );
+	}
+
+	private Set< Integer > asSet( Integer... values )
+	{
+		return new TreeSet<>( Arrays.asList( values ) );
+	}
+}


### PR DESCRIPTION
This pull request adds an `OverlappingLabels` class that allows to quantify the overlap between all pairs of labels in a given `ImgLabeling` (by creating a confusion/co-occurrence matrix).

It makes use of `FragmentProperties` from `LabelRegions`, so we need to change the field visibility of `indexToFragmentProperties` to `protected`.

The test (`OverlappingLabelsTest`) illustrates the functionality, given the following test labeling:

|   |   |   |
|---|---|---|
|   |1  |1  |
| 2 |123|1 3|
|   |  3|  3|

The labels `1` and `3` overlap by 2 pixels.

The labels `2` and `3` overlap by 1 pixel, which corresponds to fractions of `0.5` (of label `2`) and `0.25` (of label `3`).

Let me know if this would be useful to have in `imglib2-roi`. I wasn't sure about the naming, so feel free to suggest changes.
