### PR TITLE
Improve memory usage and performance of LabelingMapping.

### DIFF
--- a/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
@@ -88,13 +88,12 @@ public class LabelingMapping< T >
 
 	private final List< T > labels = new ArrayList<>();
 
-	private final TObjectIntMap< T > labelToId = new TObjectIntHashMap<>( Constants.DEFAULT_CAPACITY, Constants.DEFAULT_LOAD_FACTOR, -1);
+	private final TObjectIntMap< T > labelToId = new TObjectIntHashMap<>( Constants.DEFAULT_CAPACITY, Constants.DEFAULT_LOAD_FACTOR, -1 );
 
 	/**
 	 * the empty label set.
 	 */
 	private InternedSet< T > theEmptySet;
-
 
 	/**
 	 * Create a new {@link LabelingMapping} that maps label sets to the given
@@ -153,10 +152,11 @@ public class LabelingMapping< T >
 	 */
 	public InternedSet< T > intern( final Set< T > src )
 	{
-		return intern(asElementIds(src));
+		return intern( asElementIds( src ) );
 	}
 
-	private InternedSet< T > intern( SortedInts labelIds ) {
+	private InternedSet< T > intern( final SortedInts labelIds )
+	{
 		return internedSets.computeIfAbsent( labelIds, this::create );
 	}
 
@@ -173,7 +173,7 @@ public class LabelingMapping< T >
 	 */
 	public Set< T > getLabels()
 	{
-		return new HashSet<>(labels);
+		return new HashSet<>( labels );
 	}
 
 	/**
@@ -234,17 +234,18 @@ public class LabelingMapping< T >
 		setsByIndex.trimToSize();
 	}
 
-	private synchronized InternedSet< T > create( SortedInts labelIds ) {
+	private synchronized InternedSet< T > create( final SortedInts labelIds )
+	{
 		final int index = setsByIndex.size();
 		if ( index > maxNumLabelSets )
 			throw new AssertionError( String.format( "Too many labels (or types of multiply-labeled pixels): %d maximum", index ) );
 
-		InternedSet< T > internedSet = new InternedSet<>( this, labelIds, index );
+		final InternedSet< T > internedSet = new InternedSet<>( this, labelIds, index );
 		setsByIndex.add( internedSet );
 		return internedSet;
 	}
 
-	private int getLabelId( T label )
+	private int getLabelId( final T label )
 	{
 		int id = labelToId.get( label );
 		if ( id == labelToId.getNoEntryValue() )
@@ -252,34 +253,37 @@ public class LabelingMapping< T >
 		return id;
 	}
 
-	private synchronized int createLabelId(T object) {
-		int id = labelToId.get(object);
-		if(id != labelToId.getNoEntryValue())
+	private synchronized int createLabelId( final T object )
+	{
+		int id = labelToId.get( object );
+		if ( id != labelToId.getNoEntryValue() )
 			return id;
 		id = labels.size();
-		labels.add(object);
-		labelToId.put(object, id);
+		labels.add( object );
+		labelToId.put( object, id );
 		return id;
 	}
 
-	private T getLabel(int id) {
-		return labels.get(id);
+	private T getLabel( final int id )
+	{
+		return labels.get( id );
 	}
 
-	private SortedInts asElementIds(Set<T> labelSet) {
-		int[] values = new int[labelSet.size()];
-		Iterator< T > iterator = labelSet.iterator();
+	private SortedInts asElementIds( final Set< T > labelSet )
+	{
+		final int[] values = new int[ labelSet.size() ];
+		final Iterator< T > iterator = labelSet.iterator();
 		for ( int i = 0; i < values.length; i++ )
 		{
-			values[i] = getLabelId( iterator.next() );
+			values[ i ] = getLabelId( iterator.next() );
 		}
 		Arrays.sort( values );
 		return SortedInts.wrapSortedValues( values );
 	}
 
 	/**
-	 * Canonical representative for a label set. Contains the
-	 * index to which the label set is mapped.
+	 * Canonical representative for a label set. Contains the index to which the
+	 * label set is mapped.
 	 */
 	public static class InternedSet< T > extends AbstractCollection< T > implements Set< T >
 	{
@@ -289,7 +293,7 @@ public class LabelingMapping< T >
 
 		final int index;
 
-		private InternedSet( final LabelingMapping< T > container, SortedInts labelIds, int index )
+		private InternedSet( final LabelingMapping< T > container, final SortedInts labelIds, final int index )
 		{
 			this.container = container;
 			this.labelIds = labelIds;
@@ -312,7 +316,7 @@ public class LabelingMapping< T >
 		public int hashCode()
 		{
 			int hashCode = 0;
-			for(T element : this)
+			for ( final T element : this )
 				hashCode += element.hashCode();
 			return hashCode;
 		}
@@ -320,20 +324,20 @@ public class LabelingMapping< T >
 		@Override
 		public boolean equals( final Object obj )
 		{
-			if(obj instanceof InternedSet && ( ( InternedSet ) obj ).container == container)
+			if ( obj instanceof InternedSet && ( ( InternedSet ) obj ).container == container )
 				return obj == this;
 			return equalsSet( obj );
 		}
 
-		private boolean equalsSet( Object obj )
+		private boolean equalsSet( final Object obj )
 		{
-			if(!(obj instanceof Set))
+			if ( !( obj instanceof Set ) )
 				return false;
-			Set< T > other = ( Set< T > ) obj;
-			if(other.size() != this.size())
+			final Set< T > other = ( Set< T > ) obj;
+			if ( other.size() != this.size() )
 				return false;
-			for(T elem : other)
-				if(! this.contains( elem ))
+			for ( final T elem : other )
+				if ( !this.contains( elem ) )
 					return false;
 			return true;
 		}
@@ -343,8 +347,8 @@ public class LabelingMapping< T >
 		{
 			if ( o == null )
 				return false;
-			int labelId = container.labelToId.get( o );
-			if (labelId == container.labelToId.getNoEntryValue())
+			final int labelId = container.labelToId.get( o );
+			if ( labelId == container.labelToId.getNoEntryValue() )
 				return false;
 			return labelIds.contains( labelId );
 		}
@@ -368,13 +372,14 @@ public class LabelingMapping< T >
 			@Override
 			public T next()
 			{
-				return container.getLabel(labelIds.get(i++));
+				return container.getLabel( labelIds.get( i++ ) );
 			}
 		}
 	}
 
-	private Set< WeakReference< AddRemoveCacheMap > > cacheMaps = Collections.newSetFromMap(new ConcurrentHashMap<>());
-	private ReferenceQueue< AddRemoveCacheMap > referenceQueue = new ReferenceQueue<>();
+	private final Set< WeakReference< AddRemoveCacheMap > > cacheMaps = Collections.newSetFromMap( new ConcurrentHashMap<>() );
+
+	private final ReferenceQueue< AddRemoveCacheMap > referenceQueue = new ReferenceQueue<>();
 
 	private void clearCacheMaps()
 	{
@@ -393,12 +398,14 @@ public class LabelingMapping< T >
 		return cacheMap;
 	}
 
-	private void clearWeakReferences() {
-		while(true) {
-			Reference< ? extends AddRemoveCacheMap > reference = referenceQueue.poll();
-			if(reference == null)
+	private void clearWeakReferences()
+	{
+		while ( true )
+		{
+			final Reference< ? extends AddRemoveCacheMap > reference = referenceQueue.poll();
+			if ( reference == null )
 				break;
-			cacheMaps.remove(reference);
+			cacheMaps.remove( reference );
 		}
 	}
 
@@ -434,16 +441,16 @@ public class LabelingMapping< T >
 
 		public int addLabelToSetAtIndex( final T label, final int index )
 		{
-			final CachedTriple< T > triple = addCache[getTripleIndex(label, index)];
-			if (triple.fromIndex == index && triple.label.equals( label ) )
+			final CachedTriple< T > triple = addCache[ getTripleIndex( label, index ) ];
+			if ( triple.fromIndex == index && triple.label.equals( label ) )
 				return triple.toIndex;
 			else
 			{
 				// update triple
-				SortedInts labelIds = setAtIndex( index ).labelIds;
-				int labelId = getLabelId(label);
-				SortedInts newLabelIds = labelIds.copyAndAdd(labelId);
-				int toIndex = newLabelIds == labelIds ? index : intern( newLabelIds ).index;
+				final SortedInts labelIds = setAtIndex( index ).labelIds;
+				final int labelId = getLabelId( label );
+				final SortedInts newLabelIds = labelIds.copyAndAdd( labelId );
+				final int toIndex = newLabelIds == labelIds ? index : intern( newLabelIds ).index;
 				triple.fromIndex = index;
 				triple.label = label;
 				triple.toIndex = toIndex;
@@ -453,16 +460,16 @@ public class LabelingMapping< T >
 
 		public int removeLabelFromSetAtIndex( final T label, final int index )
 		{
-			final CachedTriple< T > triple = removeCache[getTripleIndex(label, index)];
-			if (triple.fromIndex == index && triple.label.equals( label ) )
+			final CachedTriple< T > triple = removeCache[ getTripleIndex( label, index ) ];
+			if ( triple.fromIndex == index && triple.label.equals( label ) )
 				return triple.toIndex;
 			else
 			{
 				// update triple
-				SortedInts labelIds = setAtIndex(index).labelIds;
-				int labelId = getLabelId(label);
-				SortedInts newLabelIds = labelIds.copyAndRemove( labelId );
-				int toIndex = newLabelIds == labelIds ? index : intern( newLabelIds ).index;
+				final SortedInts labelIds = setAtIndex( index ).labelIds;
+				final int labelId = getLabelId( label );
+				final SortedInts newLabelIds = labelIds.copyAndRemove( labelId );
+				final int toIndex = newLabelIds == labelIds ? index : intern( newLabelIds ).index;
 				triple.fromIndex = index;
 				triple.label = label;
 				triple.toIndex = toIndex;
@@ -470,8 +477,9 @@ public class LabelingMapping< T >
 			}
 		}
 
-		private int getTripleIndex(T label, int index) {
-			return (index * 37 + label.hashCode() * 31) & CACHE_MASK;
+		private int getTripleIndex( final T label, final int index )
+		{
+			return ( index * 37 + label.hashCode() * 31 ) & CACHE_MASK;
 		}
 	}
 

--- a/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
@@ -337,12 +337,7 @@ public class LabelingMapping< T >
 	{
 		final HashSet< T > result = new HashSet<>();
 		for ( final InternedSet< T > instance : setsByIndex )
-		{
-			for ( final T label : instance.set )
-			{
-				result.add( label );
-			}
-		}
+			result.addAll( instance.set );
 		return result;
 	}
 

--- a/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
@@ -238,7 +238,20 @@ public class LabelingMapping< T >
 	 */
 	InternedSet< T > addLabelToSetAtIndex( final T label, final int index )
 	{
-		final TObjectIntMap< T > addMap = addMapsByIndex.get( index );
+		TObjectIntMap< T > addMap = addMapsByIndex.get( index );
+		if ( addMap == null )
+		{
+			synchronized ( this )
+			{
+				addMap = addMapsByIndex.get( index );
+				if ( addMap == null )
+				{
+					addMap = new TObjectIntHashMap<>( Constants.DEFAULT_CAPACITY, Constants.DEFAULT_LOAD_FACTOR, INT_NO_ENTRY_VALUE );
+					addMapsByIndex.set( index, addMap );
+				}
+			}
+		}
+
 		int i = addMap.get( label );
 		if ( i != INT_NO_ENTRY_VALUE )
 			return setsByIndex.get( i );
@@ -263,7 +276,20 @@ public class LabelingMapping< T >
 	 */
 	InternedSet< T > removeLabelFromSetAtIndex( final T label, final int index )
 	{
-		final TObjectIntMap< T > subMap = subMapsByIndex.get( index );
+		TObjectIntMap< T > subMap = subMapsByIndex.get( index );
+		if ( subMap == null )
+		{
+			synchronized ( this )
+			{
+				subMap = subMapsByIndex.get( index );
+				if ( subMap == null )
+				{
+					subMap = new TObjectIntHashMap<>( Constants.DEFAULT_CAPACITY, Constants.DEFAULT_LOAD_FACTOR, INT_NO_ENTRY_VALUE );
+					subMapsByIndex.set( index, subMap );
+				}
+			}
+		}
+
 		int i = subMap.get( label );
 		if ( i != INT_NO_ENTRY_VALUE )
 			return setsByIndex.get( i );
@@ -367,8 +393,8 @@ public class LabelingMapping< T >
 		// add back the empty set
 		final InternedSet< T > theEmptySet = this.theEmptySet;
 		setsByIndex.add( theEmptySet );
-		addMapsByIndex.add( new TObjectIntHashMap< T >( Constants.DEFAULT_CAPACITY, Constants.DEFAULT_LOAD_FACTOR, INT_NO_ENTRY_VALUE ) );
-		subMapsByIndex.add( new TObjectIntHashMap< T >( Constants.DEFAULT_CAPACITY, Constants.DEFAULT_LOAD_FACTOR, INT_NO_ENTRY_VALUE ) );
+		addMapsByIndex.add( null );
+		subMapsByIndex.add( null );
 		internedSets.put( theEmptySet.getSet(), theEmptySet );
 
 		// add remaining label sets

--- a/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
@@ -107,7 +107,7 @@ public class LabelingMapping< T >
 	private LabelingMapping( final int maxNumLabelSets )
 	{
 		this.maxNumLabelSets = maxNumLabelSets;
-		theEmptySet = intern( SortedInts.wrapSortedValues() );
+		theEmptySet = intern( SortedInts.emptyList() );
 	}
 
 	/**
@@ -123,7 +123,7 @@ public class LabelingMapping< T >
 		clearCacheMaps();
 		setsByIndex.clear();
 		internedSets.clear();
-		theEmptySet = intern( SortedInts.wrapSortedValues() );
+		theEmptySet = intern( SortedInts.emptyList() );
 	}
 
 	public InternedSet< T > emptySet()

--- a/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import gnu.trove.impl.Constants;
 import gnu.trove.map.TObjectIntMap;
 import gnu.trove.map.hash.TObjectIntHashMap;
 import net.imglib2.type.numeric.IntegerType;
@@ -86,7 +87,8 @@ public class LabelingMapping< T >
 	private final Map< SortedInts, InternedSet< T > > internedSets = new ConcurrentHashMap<>();
 
 	private final List< T > labels = new ArrayList<>();
-	private final TObjectIntMap< T > labelToId = new TObjectIntHashMap<>();
+
+	private final TObjectIntMap< T > labelToId = new TObjectIntHashMap<>( Constants.DEFAULT_CAPACITY, Constants.DEFAULT_LOAD_FACTOR, -1);
 
 	/**
 	 * the empty label set.
@@ -309,13 +311,31 @@ public class LabelingMapping< T >
 		@Override
 		public int hashCode()
 		{
-			return index;
+			int hashCode = 0;
+			for(T element : this)
+				hashCode += element.hashCode();
+			return hashCode;
 		}
 
 		@Override
 		public boolean equals( final Object obj )
 		{
-			return obj == this;
+			if(obj instanceof InternedSet && ( ( InternedSet ) obj ).container == container)
+				return obj == this;
+			return equalsSet( obj );
+		}
+
+		private boolean equalsSet( Object obj )
+		{
+			if(!(obj instanceof Set))
+				return false;
+			Set< T > other = ( Set< T > ) obj;
+			if(other.size() != this.size())
+				return false;
+			for(T elem : other)
+				if(! this.contains( elem ))
+					return false;
+			return true;
 		}
 
 		@Override

--- a/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelingMapping.java
@@ -411,13 +411,9 @@ public class LabelingMapping< T >
 
 	class AddRemoveCacheMap
 	{
-		private static final int numSignificantIndexBits = 4;
-		private static final int significantIndexValues = ( 1 << numSignificantIndexBits );
-		private static final int significantIndexBitsMask = significantIndexValues - 1;
-
-		private static final int numSignificantLabelBits = 4;
-		private static final int significantLabelValues = ( 1 << numSignificantLabelBits );
-		private static final int significantLabelBitsMask = significantLabelValues - 1;
+		private static final int CACHE_BITS = 8;
+		private static final int CACHE_SIZE = ( 1 << CACHE_BITS );
+		private static final int CACHE_MASK = CACHE_SIZE - 1;
 
 		final CachedTriple< T >[] addCache;
 		final CachedTriple< T >[] removeCache;
@@ -425,8 +421,8 @@ public class LabelingMapping< T >
 		@SuppressWarnings( { "unchecked", "raw" } )
 		AddRemoveCacheMap()
 		{
-			addCache = new CachedTriple[ significantIndexValues * significantLabelValues ];
-			removeCache = new CachedTriple[ significantIndexValues * significantLabelValues ];
+			addCache = new CachedTriple[ CACHE_SIZE ];
+			removeCache = new CachedTriple[ CACHE_SIZE ];
 			clear();
 		}
 
@@ -475,9 +471,7 @@ public class LabelingMapping< T >
 		}
 
 		private int getTripleIndex(T label, int index) {
-			final int row = index & significantIndexBitsMask;
-			final int col = label.hashCode() & significantLabelBitsMask;
-			return row * significantIndexValues + col;
+			return (index * 37 + label.hashCode() * 31) & CACHE_MASK;
 		}
 	}
 

--- a/src/main/java/net/imglib2/roi/labeling/LabelingType.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelingType.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -64,6 +64,8 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 
 	protected final LabelingMapping< T > mapping;
 
+	private final LabelingMapping< T >.AddRemoveCacheMap addRemoveCache;
+
 	protected final IntegerType< ? > type;
 
 	/**
@@ -80,6 +82,7 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 	{
 		this.type = type;
 		this.mapping = mapping;
+		this.addRemoveCache = mapping.createAddRemoveCacheMap();
 		this.generation = modCount;
 	}
 
@@ -123,7 +126,7 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 	@Override
 	public String toString()
 	{
-		return mapping.setAtIndex( type.getInteger() ).set.toString();
+		return mapping.setAtIndex( type.getInteger() ).toString();
 	}
 
 	/**
@@ -164,7 +167,7 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 	public boolean add( final T label )
 	{
 		final int index = type.getInteger();
-		final int newindex = mapping.addLabelToSetAtIndex( label, index ).index;
+		final int newindex = addRemoveCache.addLabelToSetAtIndex( label, index );
 		if ( newindex == index )
 			return false;
 		type.setInteger( newindex );
@@ -178,7 +181,7 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 		final int index = type.getInteger();
 		int newindex = index;
 		for ( final T label : c )
-			newindex = mapping.addLabelToSetAtIndex( label, newindex ).index;
+			newindex = addRemoveCache.addLabelToSetAtIndex( label, newindex );
 		if ( newindex == index )
 			return false;
 		type.setInteger( newindex );
@@ -201,19 +204,19 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 	@Override
 	public boolean contains( final Object label )
 	{
-		return mapping.setAtIndex( type.getInteger() ).set.contains( label );
+		return mapping.setAtIndex( type.getInteger() ).contains( label );
 	}
 
 	@Override
 	public boolean containsAll( final Collection< ? > labels )
 	{
-		return mapping.setAtIndex( type.getInteger() ).set.containsAll( labels );
+		return mapping.setAtIndex( type.getInteger() ).containsAll( labels );
 	}
 
 	@Override
 	public boolean isEmpty()
 	{
-		return mapping.setAtIndex( type.getInteger() ).set.isEmpty();
+		return mapping.setAtIndex( type.getInteger() ).isEmpty();
 	}
 
 	/**
@@ -224,27 +227,7 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 	@Override
 	public Iterator< T > iterator()
 	{
-		final Iterator< T > iter = mapping.setAtIndex( type.getInteger() ).set.iterator();
-		return new Iterator< T >()
-		{
-			@Override
-			public boolean hasNext()
-			{
-				return iter.hasNext();
-			}
-
-			@Override
-			public T next()
-			{
-				return iter.next();
-			}
-
-			@Override
-			public void remove()
-			{
-				throw new UnsupportedOperationException();
-			}
-		};
+		return mapping.setAtIndex( type.getInteger() ).iterator();
 	}
 
 	@SuppressWarnings( "unchecked" )
@@ -252,7 +235,7 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 	public boolean remove( final Object label )
 	{
 		final int index = type.getInteger();
-		final int newindex = mapping.removeLabelFromSetAtIndex( ( T ) label, index ).index;
+		final int newindex = addRemoveCache.removeLabelFromSetAtIndex( ( T ) label, index );
 		if ( newindex == index )
 			return false;
 		type.setInteger( newindex );
@@ -267,7 +250,7 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 		final int index = type.getInteger();
 		int newindex = index;
 		for ( final T label : ( Collection< ? extends T > ) c )
-			newindex = mapping.removeLabelFromSetAtIndex( label, newindex ).index;
+			newindex = addRemoveCache.removeLabelFromSetAtIndex( label, newindex );
 		if ( newindex == index )
 			return false;
 		type.setInteger( newindex );
@@ -284,19 +267,19 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 	@Override
 	public int size()
 	{
-		return mapping.setAtIndex( type.getInteger() ).set.size();
+		return mapping.setAtIndex( type.getInteger() ).size();
 	}
 
 	@Override
 	public Object[] toArray()
 	{
-		return mapping.setAtIndex( type.getInteger() ).set.toArray();
+		return mapping.setAtIndex( type.getInteger() ).toArray();
 	}
 
 	@Override
 	public < T1 > T1[] toArray( final T1[] a )
 	{
-		return mapping.setAtIndex( type.getInteger() ).set.toArray( a );
+		return mapping.setAtIndex( type.getInteger() ).toArray( a );
 	}
 
 	@Override
@@ -315,18 +298,18 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 			if ( c.mapping == mapping )
 				return c.type.getInteger() == type.getInteger();
 		}
-		return mapping.setAtIndex( type.getInteger() ).set.equals( obj );
+		return mapping.setAtIndex( type.getInteger() ).equals( obj );
 	}
 
 	/**
 	 * Creates a new {@link LabelingType} based on the underlying
 	 * {@link IntegerType} of the existing {@link LabelingType} with a different
 	 * label type L
-	 * 
+	 *
 	 * @param newType
 	 *            the type of the labels of the created {@link LabelingType}
-	 * 
-	 * @return new {@link LabelingType} 
+	 *
+	 * @return new {@link LabelingType}
 	 */
 	public < L > LabelingType< L > createVariable( Class< ? extends L > newType )
 	{

--- a/src/main/java/net/imglib2/roi/labeling/LabelingType.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelingType.java
@@ -285,7 +285,7 @@ public class LabelingType< T > implements Type< LabelingType< T > >, Set< T >
 	@Override
 	public int hashCode()
 	{
-		return mapping.setAtIndex( type.getInteger() ).hashCode;
+		return mapping.setAtIndex( type.getInteger() ).hashCode();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/roi/labeling/SortedInts.java
+++ b/src/main/java/net/imglib2/roi/labeling/SortedInts.java
@@ -1,0 +1,127 @@
+package net.imglib2.roi.labeling;
+
+import java.util.Arrays;
+
+/**
+ * A immutable sorted list of integers, with unique values.
+ * <p>
+ * This class doesn't implement any list interfaces.
+ *
+ * @author Matthias Arzt
+ */
+class SortedInts
+{
+
+	private static final SortedInts EMPTY_LIST = wrapSortedValues();
+
+	private final int[] values;
+
+	private final int hashCode;
+
+	private SortedInts( int sortedValues[] )
+	{
+		this.values = sortedValues;
+		this.hashCode = Arrays.hashCode( sortedValues );
+	}
+
+	public static SortedInts emptyList()
+	{
+		return EMPTY_LIST;
+	}
+
+	@Override
+	public boolean equals( Object obj )
+	{
+		if ( this == obj )
+			return true;
+		if ( !( obj instanceof SortedInts ) )
+			return false;
+		SortedInts other = ( SortedInts ) obj;
+		if ( hashCode != other.hashCode )
+			return false;
+		return Arrays.equals( values, other.values );
+	}
+
+	public boolean contains( int value )
+	{
+		return Arrays.binarySearch( values, value ) >= 0;
+	}
+
+	/**
+	 * @return A new SortedInts object, that contains all the values of this object
+	 * plus the specified value. Simply returns this if the specified value is
+	 * already in the list.
+	 */
+	public SortedInts copyAndAdd( int value )
+	{
+		int index = Arrays.binarySearch( values, value );
+		if ( index >= 0 )
+			return this;
+		int insertionPoint = -1 - index;
+		int[] newValues = new int[ values.length + 1 ];
+		System.arraycopy( values, 0, newValues, 0, insertionPoint );
+		newValues[ insertionPoint ] = value;
+		System.arraycopy( values, insertionPoint, newValues, insertionPoint + 1, values.length - insertionPoint );
+		return SortedInts.wrapSortedValues( newValues );
+	}
+
+	/**
+	 * @return A new SortedInts object, that contains all the values of this object
+	 * except the specified value. Simply returns {@code this} if the specified value
+	 * is not in the list.
+	 */
+	public SortedInts copyAndRemove( int value )
+	{
+		int index = Arrays.binarySearch( values, value );
+		if ( index < 0 )
+			return this;
+		int[] newValues = new int[ values.length - 1 ];
+		System.arraycopy( values, 0, newValues, 0, index );
+		System.arraycopy( values, index + 1, newValues, index, values.length - index - 1 );
+		return SortedInts.wrapSortedValues( newValues );
+	}
+
+	public static SortedInts create( int... values )
+	{
+		int[] newValues = Arrays.copyOf( values, values.length );
+		Arrays.sort( newValues );
+		return new SortedInts( newValues );
+	}
+
+	public static SortedInts wrapSortedValues( int... sortedValues )
+	{
+		return new SortedInts( sortedValues );
+	}
+
+	public int[] toArray()
+	{
+		return Arrays.copyOf( values, values.length );
+	}
+
+	@Override
+	public String toString()
+	{
+		return Arrays.toString( values );
+	}
+
+	public int size()
+	{
+		return values.length;
+	}
+
+	public boolean isEmpty()
+	{
+		return values.length == 0;
+	}
+
+	public int get( int i )
+	{
+		return values[ i ];
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return hashCode;
+	}
+}

--- a/src/main/java/net/imglib2/roi/labeling/SortedInts.java
+++ b/src/main/java/net/imglib2/roi/labeling/SortedInts.java
@@ -11,14 +11,13 @@ import java.util.Arrays;
  */
 class SortedInts
 {
-
 	private static final SortedInts EMPTY_LIST = wrapSortedValues();
 
 	private final int[] values;
 
 	private final int hashCode;
 
-	private SortedInts( int sortedValues[] )
+	private SortedInts( final int[] sortedValues )
 	{
 		this.values = sortedValues;
 		this.hashCode = Arrays.hashCode( sortedValues );
@@ -30,19 +29,19 @@ class SortedInts
 	}
 
 	@Override
-	public boolean equals( Object obj )
+	public boolean equals( final Object obj )
 	{
 		if ( this == obj )
 			return true;
 		if ( !( obj instanceof SortedInts ) )
 			return false;
-		SortedInts other = ( SortedInts ) obj;
+		final SortedInts other = ( SortedInts ) obj;
 		if ( hashCode != other.hashCode )
 			return false;
 		return Arrays.equals( values, other.values );
 	}
 
-	public boolean contains( int value )
+	public boolean contains( final int value )
 	{
 		return Arrays.binarySearch( values, value ) >= 0;
 	}
@@ -52,13 +51,13 @@ class SortedInts
 	 * plus the specified value. Simply returns this if the specified value is
 	 * already in the list.
 	 */
-	public SortedInts copyAndAdd( int value )
+	public SortedInts copyAndAdd( final int value )
 	{
-		int index = Arrays.binarySearch( values, value );
+		final int index = Arrays.binarySearch( values, value );
 		if ( index >= 0 )
 			return this;
-		int insertionPoint = -1 - index;
-		int[] newValues = new int[ values.length + 1 ];
+		final int insertionPoint = -1 - index;
+		final int[] newValues = new int[ values.length + 1 ];
 		System.arraycopy( values, 0, newValues, 0, insertionPoint );
 		newValues[ insertionPoint ] = value;
 		System.arraycopy( values, insertionPoint, newValues, insertionPoint + 1, values.length - insertionPoint );
@@ -70,25 +69,25 @@ class SortedInts
 	 * except the specified value. Simply returns {@code this} if the specified value
 	 * is not in the list.
 	 */
-	public SortedInts copyAndRemove( int value )
+	public SortedInts copyAndRemove( final int value )
 	{
-		int index = Arrays.binarySearch( values, value );
+		final int index = Arrays.binarySearch( values, value );
 		if ( index < 0 )
 			return this;
-		int[] newValues = new int[ values.length - 1 ];
+		final int[] newValues = new int[ values.length - 1 ];
 		System.arraycopy( values, 0, newValues, 0, index );
 		System.arraycopy( values, index + 1, newValues, index, values.length - index - 1 );
 		return SortedInts.wrapSortedValues( newValues );
 	}
 
-	public static SortedInts create( int... values )
+	public static SortedInts create( final int... values )
 	{
-		int[] newValues = Arrays.copyOf( values, values.length );
+		final int[] newValues = Arrays.copyOf( values, values.length );
 		Arrays.sort( newValues );
 		return new SortedInts( newValues );
 	}
 
-	public static SortedInts wrapSortedValues( int... sortedValues )
+	public static SortedInts wrapSortedValues( final int... sortedValues )
 	{
 		return new SortedInts( sortedValues );
 	}
@@ -114,7 +113,7 @@ class SortedInts
 		return values.length == 0;
 	}
 
-	public int get( int i )
+	public int get( final int i )
 	{
 		return values[ i ];
 	}

--- a/src/test/java/net/imglib2/roi/labeling/ImgLabelingTest.java
+++ b/src/test/java/net/imglib2/roi/labeling/ImgLabelingTest.java
@@ -36,17 +36,20 @@ package net.imglib2.roi.labeling;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.UnsignedIntType;
 
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Matthias Arzt
@@ -109,5 +112,17 @@ public class ImgLabelingTest {
 
 	private <T> Set<T> asSet(T... values) {
 		return new TreeSet<>(Arrays.asList(values));
+	}
+
+	@Test
+	public void testHashCodeAndEquals()
+	{
+		ImgLabeling< String, IntType > labeling = new ImgLabeling<>( ArrayImgs.ints( 1, 1 ) );
+		LabelingType< String > pixel = labeling.firstElement();
+		pixel.add( "foo" );
+		pixel.add( "bar" );
+		HashSet< String > expected = new HashSet<>( Arrays.asList( "foo", "bar" ) );
+		assertTrue( pixel.equals( expected ) );
+		assertEquals( expected.hashCode(), pixel.hashCode() );
 	}
 }

--- a/src/test/java/net/imglib2/roi/labeling/LabelingBenchmark.java
+++ b/src/test/java/net/imglib2/roi/labeling/LabelingBenchmark.java
@@ -33,6 +33,8 @@
  */
 package net.imglib2.roi.labeling;
 
+import java.util.Random;
+
 import net.imglib2.Cursor;
 import net.imglib2.Localizable;
 import net.imglib2.Point;
@@ -43,18 +45,16 @@ import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.util.StopWatch;
 import net.imglib2.view.Views;
 
-import java.util.Random;
-
 /**
- * Draws 100,000 spheres in a ImgLabeling of size 500 * 500 * 500.
- * Measures performance & memory usage.
+ * Draws 100,000 spheres in a ImgLabeling of size 500 * 500 * 500. Measures
+ * performance & memory usage.
  *
  * @author Matthias Arzt
  */
 public class LabelingBenchmark
 {
 
-	public static void main( String... args )
+	public static void main( final String... args )
 	{
 		final Img< IntType > image = ArrayImgs.ints( 500, 500, 500 );
 		final ImgLabeling< Integer, ? > labeling = new ImgLabeling<>( image );
@@ -72,15 +72,15 @@ public class LabelingBenchmark
 			System.out.println( subwatch );
 		}
 		System.out.println( watch );
-		System.out.println( (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1024 / 1024 + " MB");
+		System.out.println( ( Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() ) / 1024 / 1024 + " MB" );
 		System.gc();
 		System.gc();
-		System.out.println( (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1024 / 1024 + " MB");
+		System.out.println( ( Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() ) / 1024 / 1024 + " MB" );
 		System.out.println( "Number of label sets: " + labeling.getMapping().getLabelSets().size() );
 	}
 
-	private static < T > void draw( ImgLabeling< T, ? > image,
-			MaskInterval shape, T b )
+	private static < T > void draw( final ImgLabeling< T, ? > image,
+			final MaskInterval shape, final T b )
 	{
 		final Cursor< LabelingType< T > > cursor =
 				Views.interval( image, shape ).cursor();
@@ -116,23 +116,23 @@ public class LabelingBenchmark
 		}
 
 		@Override
-		public long min( int d )
+		public long min( final int d )
 		{
 			return Math.max( 0, center.getLongPosition( d ) - 10 );
 		}
 
 		@Override
-		public long max( int d )
+		public long max( final int d )
 		{
 			return Math.min( 499, center.getLongPosition( d ) + 10 );
 		}
 
 		@Override
-		public boolean test( Localizable localizable )
+		public boolean test( final Localizable localizable )
 		{
-			long x = localizable.getLongPosition( 0 ) - center.getLongPosition( 0 );
-			long y = localizable.getLongPosition( 1 ) - center.getLongPosition( 1 );
-			long z = localizable.getLongPosition( 2 ) - center.getLongPosition( 2 );
+			final long x = localizable.getLongPosition( 0 ) - center.getLongPosition( 0 );
+			final long y = localizable.getLongPosition( 1 ) - center.getLongPosition( 1 );
+			final long z = localizable.getLongPosition( 2 ) - center.getLongPosition( 2 );
 			return 0 > x * x + y * y + z * z - r2;
 		}
 

--- a/src/test/java/net/imglib2/roi/labeling/LabelingBenchmark.java
+++ b/src/test/java/net/imglib2/roi/labeling/LabelingBenchmark.java
@@ -1,0 +1,145 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2020 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.roi.labeling;
+
+import net.imglib2.Cursor;
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.roi.MaskInterval;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.util.StopWatch;
+import net.imglib2.view.Views;
+
+import java.util.Random;
+
+/**
+ * Draws 100,000 spheres in a ImgLabeling of size 500 * 500 * 500.
+ * Measures performance & memory usage.
+ *
+ * @author Matthias Arzt
+ */
+public class LabelingBenchmark
+{
+
+	public static void main( String... args )
+	{
+		final Img< IntType > image = ArrayImgs.ints( 500, 500, 500 );
+		final ImgLabeling< Integer, ? > labeling = new ImgLabeling<>( image );
+		final RandomSphere shape = new RandomSphere();
+		final int count = 100000;
+		final StopWatch watch = StopWatch.createAndStart();
+		for ( int j = 0; j < 10; j++ )
+		{
+			final StopWatch subwatch = StopWatch.createAndStart();
+			for ( int i = count / 10 * j; i < count / 10 * ( j + 1 ); i++ )
+			{
+				shape.randomize();
+				draw( labeling, shape, i );
+			}
+			System.out.println( subwatch );
+		}
+		System.out.println( watch );
+		System.out.println( (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1024 / 1024 + " MB");
+		System.gc();
+		System.gc();
+		System.out.println( (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1024 / 1024 + " MB");
+		System.out.println( "Number of label sets: " + labeling.getMapping().getLabelSets().size() );
+	}
+
+	private static < T > void draw( ImgLabeling< T, ? > image,
+			MaskInterval shape, T b )
+	{
+		final Cursor< LabelingType< T > > cursor =
+				Views.interval( image, shape ).cursor();
+		while ( cursor.hasNext() )
+		{
+			cursor.fwd();
+			if ( shape.test( cursor ) )
+				cursor.get().add( b );
+		}
+	}
+
+	static class RandomSphere implements MaskInterval
+	{
+
+		private final Point center = new Point( 3 );
+
+		private long r, r2;
+
+		private final Random random = new Random( 1 );
+
+		RandomSphere()
+		{
+			randomize();
+		}
+
+		public void randomize()
+		{
+			center.setPosition( random.nextInt( 500 ), 0 );
+			center.setPosition( random.nextInt( 500 ), 1 );
+			center.setPosition( random.nextInt( 500 ), 2 );
+			r = random.nextInt( 5 ) + 7;
+			r2 = r * r;
+		}
+
+		@Override
+		public long min( int d )
+		{
+			return Math.max( 0, center.getLongPosition( d ) - 10 );
+		}
+
+		@Override
+		public long max( int d )
+		{
+			return Math.min( 499, center.getLongPosition( d ) + 10 );
+		}
+
+		@Override
+		public boolean test( Localizable localizable )
+		{
+			long x = localizable.getLongPosition( 0 ) - center.getLongPosition( 0 );
+			long y = localizable.getLongPosition( 1 ) - center.getLongPosition( 1 );
+			long z = localizable.getLongPosition( 2 ) - center.getLongPosition( 2 );
+			return 0 > x * x + y * y + z * z - r2;
+		}
+
+		@Override
+		public int numDimensions()
+		{
+			return 3;
+		}
+	}
+}

--- a/src/test/java/net/imglib2/roi/labeling/SortedIntsTest.java
+++ b/src/test/java/net/imglib2/roi/labeling/SortedIntsTest.java
@@ -1,13 +1,13 @@
 package net.imglib2.roi.labeling;
 
-import org.junit.Test;
-
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * Tests {@link SortedInts}.
@@ -48,7 +48,7 @@ public class SortedIntsTest
 	@Test
 	public void testCreate()
 	{
-		SortedInts list = SortedInts.create( new int[] { 3, 5, 4 } );
+		final SortedInts list = SortedInts.create( 3, 5, 4 );
 		assertArrayEquals( new int[] { 3, 4, 5 }, list.toArray() );
 	}
 
@@ -74,7 +74,7 @@ public class SortedIntsTest
 	@Test
 	public void testToString()
 	{
-		SortedInts a = SortedInts.wrapSortedValues( 1, 4, 7 );
+		final SortedInts a = SortedInts.wrapSortedValues( 1, 4, 7 );
 		assertEquals( "[1, 4, 7]", a.toString() );
 	}
 

--- a/src/test/java/net/imglib2/roi/labeling/SortedIntsTest.java
+++ b/src/test/java/net/imglib2/roi/labeling/SortedIntsTest.java
@@ -1,0 +1,99 @@
+package net.imglib2.roi.labeling;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link SortedInts}.
+ */
+public class SortedIntsTest
+{
+	private final SortedInts example = SortedInts.wrapSortedValues( 1, 4, 7 );
+
+	@Test
+	public void testSize()
+	{
+		assertEquals( 3, example.size() );
+	}
+
+	@Test
+	public void testIsEmpty()
+	{
+		assertFalse( example.isEmpty() );
+		assertTrue( SortedInts.emptyList().isEmpty() );
+	}
+
+	@Test
+	public void testGet()
+	{
+		assertEquals( 4, example.get( 1 ) );
+	}
+
+	@Test
+	public void testContains()
+	{
+		assertTrue( example.contains( 1 ) );
+		assertTrue( example.contains( 4 ) );
+		assertTrue( example.contains( 7 ) );
+		assertFalse( example.contains( 0 ) );
+		assertFalse( example.contains( 8 ) );
+	}
+
+	@Test
+	public void testCreate()
+	{
+		SortedInts list = SortedInts.create( new int[] { 3, 5, 4 } );
+		assertArrayEquals( new int[] { 3, 4, 5 }, list.toArray() );
+	}
+
+	@Test
+	public void testEquals()
+	{
+		final SortedInts same = SortedInts.wrapSortedValues( 1, 4, 7 );
+		final SortedInts different = SortedInts.wrapSortedValues( 1, 4, 8 );
+		assertEquals( example, example );
+		assertEquals( example, same );
+		assertNotEquals( example, different );
+	}
+
+	@Test
+	public void testHashCode()
+	{
+		final SortedInts same = SortedInts.wrapSortedValues( 1, 4, 7 );
+		final SortedInts different = SortedInts.wrapSortedValues( 1, 4, 8 );
+		assertEquals( example.hashCode(), same.hashCode() );
+		assertNotEquals( example.hashCode(), different.hashCode() );
+	}
+
+	@Test
+	public void testToString()
+	{
+		SortedInts a = SortedInts.wrapSortedValues( 1, 4, 7 );
+		assertEquals( "[1, 4, 7]", a.toString() );
+	}
+
+	@Test
+	public void testAdd()
+	{
+		assertEquals( SortedInts.wrapSortedValues( 0, 1, 4, 7 ), example.copyAndAdd( 0 ) );
+		assertEquals( SortedInts.wrapSortedValues( 1, 2, 4, 7 ), example.copyAndAdd( 2 ) );
+		assertEquals( SortedInts.wrapSortedValues( 1, 4, 7, 8 ), example.copyAndAdd( 8 ) );
+		assertSame( example, example.copyAndAdd( 1 ) );
+		assertEquals( SortedInts.wrapSortedValues( 1, 4, 7 ), example );
+	}
+
+	@Test
+	public void testRemove()
+	{
+		assertEquals( SortedInts.wrapSortedValues( 4, 7 ), example.copyAndRemove( 1 ) );
+		assertEquals( SortedInts.wrapSortedValues( 1, 7 ), example.copyAndRemove( 4 ) );
+		assertEquals( SortedInts.wrapSortedValues( 1, 4 ), example.copyAndRemove( 7 ) );
+		assertSame( example, example.copyAndRemove( 5 ) );
+	}
+}


### PR DESCRIPTION
This PR contains many ideas to improve the performance of LabelingMapping.

Changes by @tpietzsch 

* All sets in Labeling.setsByIndex are backed by one consecutive list of there elements stored in Labeling.data. This saves a lot of array headers.
(This solution couldn't show it's full performance, as Labeling.internedSet is a Map<Set<T>, InternedSet<T>> where regular HashSets where used as keys. A lot more memory can be saved when InternedSet is used a the key as well.)


Changes by @maarzt 
* Have a bimapping between labels and integer ids. Instead of using Set<T> use a set of integers. The set of integers is represented as a sorted TIntArrayList. Advantages:
  * Two lists of ints can be much faster compared than two Set<T>.
* Have a dedicated class 'SortedInts' to represent the set of integers, which internally uses a sorted integer array:
  * `SortedInts` has a much better hash code, improving the performance of the internedSet Hashmap.
* Use a better hash function in AddRemoveCacheMap.
* Use ReferenceQueue with WeakReference<AddRemoveCacheMap>:
   * This improves performance of the  clearWeakReferences method. And as a side effect fixes problems with concurrent modification issues of LabelingMapping.cacheMaps.
* Fix hashCode and equals method of InternedSet