### PR TITLE
Add helper methods

### DIFF
--- a/src/main/java/net/imglib2/roi/labeling/Labelings.java
+++ b/src/main/java/net/imglib2/roi/labeling/Labelings.java
@@ -137,7 +137,7 @@ public class Labelings
 		Set< I > occurringValues = new HashSet<>();
 		for ( I pixel : Views.iterable( img.getIndexImg() ) )
 		{
-			if ( pixel.getInteger() > 0 )
+			if ( pixel.getInteger() > 0 && !occurringValues.contains( pixel ))
 				occurringValues.add( pixel.copy() );
 		}
 

--- a/src/main/java/net/imglib2/roi/labeling/Labelings.java
+++ b/src/main/java/net/imglib2/roi/labeling/Labelings.java
@@ -132,7 +132,7 @@ public class Labelings
 	 *
 	 * @return {@link Set} of occurring pixel values
 	 */
-	static < T, I extends IntegerType< I > > Set< I > getOccurringPixelSets( ImgLabeling< T, I > img )
+	public static < T, I extends IntegerType< I > > Set< I > getOccurringPixelSets( ImgLabeling< T, I > img )
 	{
 		Set< I > occurringValues = new HashSet<>();
 		for ( I pixel : Views.iterable( img.getIndexImg() ) )
@@ -157,7 +157,7 @@ public class Labelings
 	 *
 	 * @return True if the image labeling has intersecting labels, false otherwise.
 	 */
-	static < T, I extends IntegerType< I > > boolean hasIntersectingLabels( ImgLabeling< T, I > img )
+	public static < T, I extends IntegerType< I > > boolean hasIntersectingLabels( ImgLabeling< T, I > img )
 	{
 		List< Set< T > > labelSets = img.getMapping().getLabelSets();
 		for ( I i : getOccurringPixelSets( img ) )

--- a/src/main/java/net/imglib2/roi/labeling/Labelings.java
+++ b/src/main/java/net/imglib2/roi/labeling/Labelings.java
@@ -35,6 +35,7 @@ package net.imglib2.roi.labeling;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -117,5 +118,55 @@ public class Labelings
 		LabelingMapping< U > resultMapping = result.getMapping();
 		resultMapping.setLabelSets( resultLabelSets );
 		return result;
+	}
+
+	/**
+	 * Return a {@link Set} of occurring pixel values in the {@link ImgLabeling} index image.
+	 *
+	 * @param img
+	 * 		Image labeling from which to extract the occurring pixel values
+	 * @param <T>
+	 * 		The type of labels assigned to pixels
+	 * @param <I>
+	 * 		The pixel type of the backing image
+	 *
+	 * @return {@link Set} of occurring pixel values
+	 */
+	static < T, I extends IntegerType< I > > Set< I > getOccurringPixelSets( ImgLabeling< T, I > img )
+	{
+		Set< I > occurringValues = new HashSet<>();
+		for ( I pixel : Views.iterable( img.getIndexImg() ) )
+		{
+			if ( pixel.getInteger() > 0 )
+				occurringValues.add( pixel.copy() );
+		}
+
+		return occurringValues;
+	}
+
+	/**
+	 * Check if the image labeling {@code img} has intersecting labels. Two labels intersect if there
+	 * is at least one pixel in the image labeled with both labels.
+	 *
+	 * @param img
+	 * 		Image labeling
+	 * @param <T>
+	 * 		The type of labels assigned to pixels
+	 * @param <I>
+	 * 		The pixel type of the backing image
+	 *
+	 * @return True if the image labeling has intersecting labels, false otherwise.
+	 */
+	static < T, I extends IntegerType< I > > boolean hasIntersectingLabels( ImgLabeling< T, I > img )
+	{
+		List< Set< T > > labelSets = img.getMapping().getLabelSets();
+		for ( I i : getOccurringPixelSets( img ) )
+		{
+			if ( labelSets.get( i.getInteger() ).size() > 1 )
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/test/java/net/imglib2/roi/labeling/LabelingsTest.java
+++ b/src/test/java/net/imglib2/roi/labeling/LabelingsTest.java
@@ -34,6 +34,8 @@
 package net.imglib2.roi.labeling;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -43,6 +45,7 @@ import java.util.TreeSet;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 
 import org.junit.Test;
@@ -85,6 +88,72 @@ public class LabelingsTest
 		ImgLabeling< Integer, UnsignedByteType > labeling = ImgLabeling.fromImageAndLabelSets( indexImg, labelSets );
 		// process
 		Labelings.remapLabels( labeling, i -> "foo" );
+	}
+
+	@Test
+	public void testOcurringPixelSets()
+	{
+		final byte[] exampleIndexArray = new byte[] {
+				1, 0, 0, 0, 0,
+				0, 1, 0, 5, 0,
+				0, 0, 0, 3, 3,
+				0, 0, 3, 3, 0
+		};
+
+		Img< UnsignedByteType > indexImg = ArrayImgs.unsignedBytes( exampleIndexArray, 4, 5 );
+
+		List< Set< String > > intersectSets = Arrays.asList(
+				asSet(),
+				asSet( "A"),
+				asSet( "A", "B" ),
+				asSet( "C" ),
+				asSet( "D" ),
+				asSet( "D", "E" ));
+		ImgLabeling< String, UnsignedByteType > intersectLabeling = ImgLabeling.fromImageAndLabelSets( indexImg, intersectSets );
+
+		Set< UnsignedByteType > occIntersect = Labelings.getOccurringPixelSets( intersectLabeling );
+
+		assertEquals( 3, occIntersect.size() );
+
+		for ( UnsignedByteType it : occIntersect )
+		{
+			int i = it.getInteger();
+			assertTrue( i == 1 || i == 3 || i == 5 );
+		}
+	}
+
+	@Test
+	public void testHasIntersectingLabels()
+	{
+		final byte[] exampleIndexArray = new byte[] {
+				1, 0, 0, 0, 0,
+				0, 1, 0, 5, 0,
+				0, 0, 0, 3, 3,
+				0, 0, 3, 3, 0
+		};
+
+		Img< UnsignedByteType > indexImg = ArrayImgs.unsignedBytes( exampleIndexArray, 4, 5 );
+
+		List< Set< String > > intersectSets = Arrays.asList(
+				asSet(),
+				asSet( "A"),
+				asSet( "A", "B" ),
+				asSet( "C" ),
+				asSet( "D" ),
+				asSet( "D", "E" ));
+		List< Set< String > > nonIntersectSets = Arrays.asList(
+				asSet(),
+				asSet( "A"),
+				asSet( "A","B" ),
+				asSet( "C" ),
+				asSet( "D" ),
+				asSet( "E" ));
+
+		ImgLabeling< String, UnsignedByteType > intersectLabeling = ImgLabeling.fromImageAndLabelSets( indexImg, intersectSets );
+		assertTrue( Labelings.hasIntersectingLabels( intersectLabeling ) );
+
+		ImgLabeling< String, UnsignedByteType > nonIntersectLabeling = ImgLabeling.fromImageAndLabelSets( indexImg, nonIntersectSets );
+		assertFalse( Labelings.hasIntersectingLabels( nonIntersectLabeling ) );
 	}
 
 	@SuppressWarnings( "unchecked" )


### PR DESCRIPTION
Following a PR (https://github.com/imglib/imglib2-algorithm/pull/91), I moved two helper methods out of imglib2-algorithm to imglib2-roi as they pertain to labelings.

The first method (getOccurringPixelSets) simply returns a Set of the occuring pixel values. The second method checks if there are intersecting labels in the ImgLabeling. I also added unit tests.