### PR TITLE
Split IterableRegion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>net.imglib2</groupId>
 	<artifactId>imglib2-roi</artifactId>
-	<version>0.14.2-SNAPSHOT</version>
+	<version>0.15.0-SNAPSHOT</version>
 
 	<name>ImgLib2 ROI</name>
 	<description>Regions of interest in ImgLib2.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>34.1.0</version>
+		<version>37.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -62,9 +62,6 @@ Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
 Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
 Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
 Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
-
-		<imglib2.version>6.1.0</imglib2.version>
-		<imglib2-realtransform.version>4.0.1</imglib2-realtransform.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>

--- a/src/main/java/net/imglib2/roi/IterableRegion.java
+++ b/src/main/java/net/imglib2/roi/IterableRegion.java
@@ -47,9 +47,10 @@ import net.imglib2.type.BooleanType;
  * i.e., it is assumed that all pixels outside the interval have value
  * {@code false}.
  * <p>
- * Iterating only the pixels contained in the region is indicated by
- * {@code IterableInterval<Void>}, i.e., when iterating, only the coordinates
- * that are visited are interesting. There is no associated value.
+ * Iterating only the pixels contained in the region is done via the {@code
+ * IterableInterval<Void>} {@link #inside()}. (The pixel type is {@code Void}
+ * because, when iterating, only the coordinates that are visited are
+ * interesting. There is no associated value.)
  * <p>
  * We put interfaces {@code RandomAccessibleInterval<BooleanType>}, extended by
  * {@code IterableRegion<BooleanType>}, extended by
@@ -62,5 +63,13 @@ import net.imglib2.type.BooleanType;
  *
  * @author Tobias Pietzsch
  */
-public interface IterableRegion< T extends BooleanType< T > > extends IterableInterval< Void >, RandomAccessibleInterval< T >
-{}
+public interface IterableRegion< T extends BooleanType< T > > extends RandomAccessibleInterval< T >
+{
+	/**
+	 * Get an {@code IterableInterval} view of only the pixels contained in the
+	 * region (having value {@code true}).
+	 *
+	 * @return iterable of the pixels in the region
+	 */
+	IterableInterval< Void > inside();
+}

--- a/src/main/java/net/imglib2/roi/PositionableIterableInterval.java
+++ b/src/main/java/net/imglib2/roi/PositionableIterableInterval.java
@@ -74,7 +74,7 @@ public interface PositionableIterableInterval< T > extends IterableInterval< T >
 	 *
 	 * @return the origin to which the interval is relative.
 	 */
-	public PositionableLocalizable origin();
+	PositionableLocalizable origin();
 
 	/**
 	 * Make a copy of this {@link PositionableIterableInterval} which can be
@@ -82,5 +82,5 @@ public interface PositionableIterableInterval< T > extends IterableInterval< T >
 	 *
 	 * @return a copy with an independent position
 	 */
-	public PositionableIterableInterval< T > copy();
+	PositionableIterableInterval< T > copy();
 }

--- a/src/main/java/net/imglib2/roi/PositionableIterableRegion.java
+++ b/src/main/java/net/imglib2/roi/PositionableIterableRegion.java
@@ -33,10 +33,18 @@
  */
 package net.imglib2.roi;
 
+import net.imglib2.Localizable;
+import net.imglib2.Positionable;
+import net.imglib2.roi.util.PositionableLocalizable;
 import net.imglib2.type.BooleanType;
+import net.imglib2.type.logic.BitType;
 
 /**
  * An {@link IterableRegion} that can be moved around.
+ * <p>
+ * The iterable view of {@link #inside()} pixels can also be moved around. Its
+ * position is the same as the position of this {@code
+ * PositionableIterableRegion}. Moving one will also move the other.
  * <p>
  * We put interfaces {@code RandomAccessibleInterval<BooleanType>}, extended by
  * {@code IterableRegion<BooleanType>}, extended by
@@ -49,9 +57,48 @@ import net.imglib2.type.BooleanType;
  *
  * @author Tobias Pietzsch
  */
-public interface PositionableIterableRegion< T extends BooleanType< T > >
-	extends IterableRegion< T >, PositionableIterableInterval< Void >
+public interface PositionableIterableRegion< T extends BooleanType< T > > extends IterableRegion< T >, Localizable, Positionable
 {
+	/**
+	 * Get an {@code PositionableIterableInterval} view of only the pixels contained in the
+	 * region (having value {@code true}).
+	 * <p>
+	 * The position of the {@link #inside()} view is the same as the position of
+	 * this {@code PositionableIterableRegion}. Moving one will also move the
+	 * other.
+	 *
+	 * @return iterable of the pixels in the region
+	 */
 	@Override
-	public PositionableIterableRegion< T > copy();
+	PositionableIterableInterval< Void > inside();
+
+	/**
+	 * Get the {@link Positionable}, {@link Localizable} origin of this
+	 * interval.
+	 * <p>
+	 * The origin is the relative offset of the position to the minimum. For
+	 * example if a positionable (bitmask) region is made from a {@link BitType}
+	 * image with a circular pattern, then it is more natural if the region
+	 * position refers to the center of the pattern instead of the upper left
+	 * corner of the {@link BitType} image. This can be achieved by positioning
+	 * the origin.
+	 * <p>
+	 * Assume a region is created from a 9x9 bitmask. The region initially has
+	 * min=(0,0), max=(8,8), position=(0,0). Because both position and min are
+	 * (0,0), initially origin=(0,0). Now assume the origin is moved to the
+	 * center of the bitmask using
+	 * <code>origin().setPosition(new int[]{4,4})</code>. After this,
+	 * min=(-4,-4), max=(4,4), position=(0,0), and origin=(4,4).
+	 *
+	 * @return the origin to which the interval is relative.
+	 */
+	PositionableLocalizable origin();
+
+	/**
+	 * Make a copy of this {@link PositionableIterableInterval} which can be
+	 * positioned independently.
+	 *
+	 * @return a copy with an independent position
+	 */
+	PositionableIterableRegion< T > copy();
 }

--- a/src/main/java/net/imglib2/roi/Regions.java
+++ b/src/main/java/net/imglib2/roi/Regions.java
@@ -60,6 +60,11 @@ public class Regions
 		return SamplingIterableInterval.create( region, img );
 	}
 
+	public static < T > IterableInterval< T > sample( final IterableRegion< ? > region, final RandomAccessible< T > img )
+	{
+		return sample( region.inside(), img );
+	}
+
 	/**
 	 * Given a mask and an image, return an {@link IterableInterval} over the
 	 * pixels of the image inside the mask.
@@ -106,8 +111,7 @@ public class Regions
 	// NB: this method is not named "sample" to avoid ambiguation with sample(IterableInterval<Void>, RandomAccessible<T>)
 	public static < T, B extends BooleanType< B > > IterableInterval< T > sampleWithRandomAccessible( final RandomAccessible< B > mask, final RandomAccessibleInterval< T > img )
 	{
-		final IterableInterval< Void > region = iterable( Views.interval( mask, img ) );
-		return sample( region, img );
+		return sample( iterable( Views.interval( mask, img ) ), img );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/roi/boundary/Boundary.java
+++ b/src/main/java/net/imglib2/roi/boundary/Boundary.java
@@ -135,7 +135,7 @@ public final class Boundary< T extends BooleanType< T > >
 		return randomAccess();
 	}
 
-	final class BoundaryIterable extends AbstractWrappedInterval< Interval > implements IterableInterval< Void >
+	private final class BoundaryIterable extends AbstractWrappedInterval< Interval > implements IterableInterval< Void >
 	{
 		BoundaryIterable()
 		{
@@ -179,7 +179,7 @@ public final class Boundary< T extends BooleanType< T > >
 		}
 	}
 
-	final class BoundaryCursor extends Point implements Cursor< Void >
+	private final class BoundaryCursor extends Point implements Cursor< Void >
 	{
 		private int i;
 

--- a/src/main/java/net/imglib2/roi/labeling/LabelRegion.java
+++ b/src/main/java/net/imglib2/roi/labeling/LabelRegion.java
@@ -186,7 +186,7 @@ public class LabelRegion< T > extends PositionableInterval implements Positionab
 		return inside;
 	}
 
-	class LabelRegionIterable extends AbstractWrappedPositionableLocalizable< LabelRegion > implements PositionableIterableInterval< Void >
+	private final class LabelRegionIterable extends AbstractWrappedPositionableLocalizable< LabelRegion< T > > implements PositionableIterableInterval< Void >
 	{
 		LabelRegionIterable()
 		{

--- a/src/main/java/net/imglib2/roi/util/IterableRandomAccessibleRegion.java
+++ b/src/main/java/net/imglib2/roi/util/IterableRandomAccessibleRegion.java
@@ -96,7 +96,7 @@ public class IterableRandomAccessibleRegion< T extends BooleanType< T > >
 		return inside;
 	}
 
-	class InsideIterable extends AbstractWrappedInterval< Interval > implements IterableInterval< Void >
+	private final class InsideIterable extends AbstractWrappedInterval< Interval > implements IterableInterval< Void >
 	{
 		InsideIterable()
 		{

--- a/src/main/java/net/imglib2/roi/util/IterableRandomAccessibleRegion.java
+++ b/src/main/java/net/imglib2/roi/util/IterableRandomAccessibleRegion.java
@@ -54,6 +54,8 @@ import net.imglib2.type.BooleanType;
  * {@link Cursor Cursors} are realized by wrapping source {@link RandomAccess
  * RandomAccesses} (using {@link RandomAccessibleRegionCursor}).
  *
+ * @deprecated Use {@code IterableRegionOnBooleanRAI} instead.
+ *
  * @author Tobias Pietzsch
  */
 @Deprecated
@@ -61,6 +63,8 @@ public class IterableRandomAccessibleRegion< T extends BooleanType< T > >
 	extends AbstractWrappedInterval< RandomAccessibleInterval< T > > implements IterableRegion< T >
 {
 	final long size;
+
+	private final InsideIterable inside;
 
 	public static < T extends BooleanType< T > > IterableRandomAccessibleRegion< T > create( final RandomAccessibleInterval< T > interval )
 	{
@@ -71,44 +75,7 @@ public class IterableRandomAccessibleRegion< T extends BooleanType< T > >
 	{
 		super( interval );
 		this.size = size;
-	}
-
-	@Override
-	public long size()
-	{
-		return size;
-	}
-
-	@Override
-	public Void firstElement()
-	{
-		if ( size() == 0 )
-			throw new NoSuchElementException();
-		return cursor().next();
-	}
-
-	@Override
-	public Object iterationOrder()
-	{
-		return this;
-	}
-
-	@Override
-	public Iterator< Void > iterator()
-	{
-		return cursor();
-	}
-
-	@Override
-	public Cursor< Void > cursor()
-	{
-		return new RandomAccessibleRegionCursor<>( sourceInterval, size );
-	}
-
-	@Override
-	public Cursor< Void > localizingCursor()
-	{
-		return cursor();
+		inside = new InsideIterable();
 	}
 
 	@Override
@@ -121,5 +88,57 @@ public class IterableRandomAccessibleRegion< T extends BooleanType< T > >
 	public RandomAccess< T > randomAccess( final Interval interval )
 	{
 		return sourceInterval.randomAccess( interval );
+	}
+
+	@Override
+	public IterableInterval< Void > inside()
+	{
+		return inside;
+	}
+
+	class InsideIterable extends AbstractWrappedInterval< Interval > implements IterableInterval< Void >
+	{
+		InsideIterable()
+		{
+			super( IterableRandomAccessibleRegion.this.sourceInterval );
+		}
+
+		@Override
+		public long size()
+		{
+			return size;
+		}
+
+		@Override
+		public Void firstElement()
+		{
+			if ( size() == 0 )
+				throw new NoSuchElementException();
+			return cursor().next();
+		}
+
+		@Override
+		public Object iterationOrder()
+		{
+			return this;
+		}
+
+		@Override
+		public Iterator< Void > iterator()
+		{
+			return cursor();
+		}
+
+		@Override
+		public Cursor< Void > cursor()
+		{
+			return new RandomAccessibleRegionCursor<>( IterableRandomAccessibleRegion.this.sourceInterval, size );
+		}
+
+		@Override
+		public Cursor< Void > localizingCursor()
+		{
+			return cursor();
+		}
 	}
 }

--- a/src/main/java/net/imglib2/roi/util/IterableRegionOnBooleanRAI.java
+++ b/src/main/java/net/imglib2/roi/util/IterableRegionOnBooleanRAI.java
@@ -95,7 +95,7 @@ public class IterableRegionOnBooleanRAI< T extends BooleanType< T > >
 		return inside;
 	}
 
-	class InsideIterable extends AbstractWrappedInterval< Interval > implements IterableInterval< Void >
+	private final class InsideIterable extends AbstractWrappedInterval< Interval > implements IterableInterval< Void >
 	{
 		InsideIterable()
 		{

--- a/src/main/java/net/imglib2/roi/util/IterableRegionOnBooleanRAI.java
+++ b/src/main/java/net/imglib2/roi/util/IterableRegionOnBooleanRAI.java
@@ -62,6 +62,8 @@ public class IterableRegionOnBooleanRAI< T extends BooleanType< T > >
 
 	private final IterableInterval< T > sourceIterable;
 
+	private final InsideIterable inside;
+
 	public IterableRegionOnBooleanRAI( final RandomAccessibleInterval< T > interval )
 	{
 		this( interval, Regions.countTrue( interval ) );
@@ -72,44 +74,7 @@ public class IterableRegionOnBooleanRAI< T extends BooleanType< T > >
 		super( interval );
 		this.size = size;
 		sourceIterable = Views.iterable( interval );
-	}
-
-	@Override
-	public long size()
-	{
-		return size;
-	}
-
-	@Override
-	public Void firstElement()
-	{
-		if ( size() == 0 )
-			throw new NoSuchElementException();
-		return cursor().next();
-	}
-
-	@Override
-	public Object iterationOrder()
-	{
-		return this;
-	}
-
-	@Override
-	public Iterator< Void > iterator()
-	{
-		return cursor();
-	}
-
-	@Override
-	public Cursor< Void > cursor()
-	{
-		return new TrueCursor< T >( sourceIterable.cursor(), size );
-	}
-
-	@Override
-	public Cursor< Void > localizingCursor()
-	{
-		return new TrueCursor< T >( sourceIterable.localizingCursor(), size );
+		inside = new InsideIterable();
 	}
 
 	@Override
@@ -122,5 +87,57 @@ public class IterableRegionOnBooleanRAI< T extends BooleanType< T > >
 	public RandomAccess< T > randomAccess( final Interval interval )
 	{
 		return sourceInterval.randomAccess( interval );
+	}
+
+	@Override
+	public IterableInterval< Void > inside()
+	{
+		return inside;
+	}
+
+	class InsideIterable extends AbstractWrappedInterval< Interval > implements IterableInterval< Void >
+	{
+		InsideIterable()
+		{
+			super( IterableRegionOnBooleanRAI.this );
+		}
+
+		@Override
+		public long size()
+		{
+			return size;
+		}
+
+		@Override
+		public Void firstElement()
+		{
+			if ( size() == 0 )
+				throw new NoSuchElementException();
+			return cursor().next();
+		}
+
+		@Override
+		public Object iterationOrder()
+		{
+			return this;
+		}
+
+		@Override
+		public Iterator< Void > iterator()
+		{
+			return cursor();
+		}
+
+		@Override
+		public Cursor< Void > cursor()
+		{
+			return new TrueCursor< T >( sourceIterable.cursor(), size );
+		}
+
+		@Override
+		public Cursor< Void > localizingCursor()
+		{
+			return new TrueCursor< T >( sourceIterable.localizingCursor(), size );
+		}
 	}
 }

--- a/src/main/java/net/imglib2/roi/util/PositionableWrappedIterableInterval.java
+++ b/src/main/java/net/imglib2/roi/util/PositionableWrappedIterableInterval.java
@@ -51,6 +51,7 @@ import net.imglib2.roi.PositionableIterableInterval;
  * @author Tobias Pietzsch
  * @author Christian Dietz
  */
+@Deprecated
 public class PositionableWrappedIterableInterval< T, S extends IterableInterval< T > >
 		extends PositionableInterval
 		implements PositionableIterableInterval< T >
@@ -151,13 +152,7 @@ public class PositionableWrappedIterableInterval< T, S extends IterableInterval<
 		@Override
 		public PositionableIterableIntervalCursor copy()
 		{
-			return new PositionableIterableIntervalCursor( source.copyCursor() );
-		}
-
-		@Override
-		public PositionableIterableIntervalCursor copyCursor()
-		{
-			return copy();
+			return new PositionableIterableIntervalCursor( source.copy() );
 		}
 	}
 

--- a/src/main/java/net/imglib2/roi/util/PositionableWrappedIterableRegion.java
+++ b/src/main/java/net/imglib2/roi/util/PositionableWrappedIterableRegion.java
@@ -84,7 +84,7 @@ public class PositionableWrappedIterableRegion< T extends BooleanType< T > >
 		return new RA( source.randomAccess( Intervals.translate( interval, currentOffset ) ), currentOffset );
 	}
 
-	class RA extends OffsetPositionableLocalizable< RandomAccess< T > > implements RandomAccess< T >
+	private final class RA extends OffsetPositionableLocalizable< RandomAccess< T > > implements RandomAccess< T >
 	{
 		public RA( final RandomAccess< T > source, final long[] offset )
 		{
@@ -116,7 +116,7 @@ public class PositionableWrappedIterableRegion< T extends BooleanType< T > >
 		return inside;
 	}
 
-	class InsideIterable extends AbstractWrappedPositionableLocalizable< PositionableWrappedIterableRegion< T > > implements PositionableIterableInterval< Void >
+	private final class InsideIterable extends AbstractWrappedPositionableLocalizable< PositionableWrappedIterableRegion< T > > implements PositionableIterableInterval< Void >
 	{
 		InsideIterable()
 		{
@@ -172,7 +172,7 @@ public class PositionableWrappedIterableRegion< T extends BooleanType< T > >
 		}
 	}
 
-	class PositionableInsideCursor extends OffsetLocalizable< Cursor< Void > > implements Cursor< Void >
+	private final class PositionableInsideCursor extends OffsetLocalizable< Cursor< Void > > implements Cursor< Void >
 	{
 		public PositionableInsideCursor( final Cursor< Void > cursor )
 		{

--- a/src/test/java/net/imglib2/roi/util/IterableRandomAccessibleRegionBenchmarkTest.java
+++ b/src/test/java/net/imglib2/roi/util/IterableRandomAccessibleRegionBenchmarkTest.java
@@ -101,7 +101,7 @@ public class IterableRandomAccessibleRegionBenchmarkTest
 	{
 		for ( final IterableRegion< BitType > region : regions )
 		{
-			final Cursor< Void > cursor = region.cursor();
+			final Cursor< Void > cursor = region.inside().cursor();
 			while ( cursor.hasNext() )
 				cursor.fwd();
 		}

--- a/src/test/java/net/imglib2/roi/util/IterableRegionOnBooleanRAIBenchmark.java
+++ b/src/test/java/net/imglib2/roi/util/IterableRegionOnBooleanRAIBenchmark.java
@@ -87,7 +87,7 @@ public class IterableRegionOnBooleanRAIBenchmark
 	@Benchmark
 	public void testIterableRandomAccessibleRegion( MyState state )
 	{
-		final Cursor< Void > c = state.irOld.cursor();
+		final Cursor< Void > c = state.irOld.inside().cursor();
 		while ( c.hasNext() )
 		{
 			c.next();
@@ -97,7 +97,7 @@ public class IterableRegionOnBooleanRAIBenchmark
 	@Benchmark
 	public void testIterableRegionOnBooleanRAI( MyState state )
 	{
-		final Cursor< Void > c = state.ir.cursor();
+		final Cursor< Void > c = state.ir.inside().cursor();
 		while ( c.hasNext() )
 		{
 			c.next();
@@ -107,7 +107,7 @@ public class IterableRegionOnBooleanRAIBenchmark
 	@Benchmark
 	public void testIterableRandomAccessibleRegionForNonIterableView( MyState state )
 	{
-		final Cursor< Void > c = state.irViewOld.cursor();
+		final Cursor< Void > c = state.irViewOld.inside().cursor();
 		while ( c.hasNext() )
 		{
 			c.next();
@@ -117,7 +117,7 @@ public class IterableRegionOnBooleanRAIBenchmark
 	@Benchmark
 	public void testIterableRegionOnBooleanRAIForNonIterableView( MyState state )
 	{
-		final Cursor< Void > c = state.irView.cursor();
+		final Cursor< Void > c = state.irView.inside().cursor();
 		while ( c.hasNext() )
 		{
 			c.next();

--- a/src/test/java/net/imglib2/roi/util/IterableRegionOnBooleanRAITest.java
+++ b/src/test/java/net/imglib2/roi/util/IterableRegionOnBooleanRAITest.java
@@ -93,7 +93,7 @@ public class IterableRegionOnBooleanRAITest
 	{
 		final long count = Regions.countTrue( img );
 		long countIR = 0;
-		final Cursor< Void > c = ir.cursor();
+		final Cursor< Void > c = ir.inside().cursor();
 		while ( c.hasNext() )
 		{
 			c.fwd();
@@ -107,7 +107,7 @@ public class IterableRegionOnBooleanRAITest
 	public void testCursorNext()
 	{
 		final Cursor< BitType > imgC = img.cursor();
-		final Cursor< Void > irC = ir.cursor();
+		final Cursor< Void > irC = ir.inside().cursor();
 
 		while ( imgC.hasNext() )
 		{
@@ -125,14 +125,14 @@ public class IterableRegionOnBooleanRAITest
 	public void testFirstElement()
 	{
 		// Ensure no error is thrown
-		assertTrue( ir.firstElement() == null );
+		assertTrue( ir.inside().firstElement() == null );
 	}
 
 	@Test
 	public void testCursorFwdEmptyRegion()
 	{
 		int count = 0;
-		final Cursor< Void > c = empty.cursor();
+		final Cursor< Void > c = empty.inside().cursor();
 		while ( c.hasNext() )
 		{
 			c.fwd();
@@ -148,7 +148,7 @@ public class IterableRegionOnBooleanRAITest
 		final long[] originalLocation = new long[ 2 ];
 		final long[] newLocation = new long[ 2 ];
 
-		final Cursor< Void > c = empty.cursor();
+		final Cursor< Void > c = empty.inside().cursor();
 		c.fwd();
 		c.localize( originalLocation );
 		c.next();
@@ -162,6 +162,6 @@ public class IterableRegionOnBooleanRAITest
 	public void testCursorFirstElementEmptyRegion()
 	{
 		exception.expect( NoSuchElementException.class );
-		empty.firstElement();
+		empty.inside().firstElement();
 	}
 }


### PR DESCRIPTION
adresses #70 

`IterableRegion<T extends BooleanType<T>>` no longer extends `IterableInterval<Void>`.
Instead, it exposes `IterableInterval<Void>` via the new `inside()` method.

The `inside` iterable is a view of the region. For example, re-positioning a `PositionableIterableRegion` will also re-position its `inside()` view, and vice versa.