### PR TITLE
Fix NullPointerException triggered by calling imgLabeling.getType()

### DIFF
--- a/src/main/java/net/imglib2/roi/labeling/ImgLabeling.java
+++ b/src/main/java/net/imglib2/roi/labeling/ImgLabeling.java
@@ -243,7 +243,7 @@ public class ImgLabeling< T, I extends IntegerType< I > >
 	@Override
 	public LabelingType< T > getType()
 	{
-		return new LabelingType<>( null, mapping, generation );
+		return new LabelingType<>( indexAccessible.getType(), mapping, generation );
 	}
 
 	@Override

--- a/src/test/java/net/imglib2/roi/labeling/ImgLabelingTest.java
+++ b/src/test/java/net/imglib2/roi/labeling/ImgLabelingTest.java
@@ -34,6 +34,7 @@
 package net.imglib2.roi.labeling;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -173,5 +174,15 @@ public class ImgLabelingTest
 		final HashSet< String > expected = new HashSet<>( Arrays.asList( "foo", "bar" ) );
 		assertTrue( pixel.equals( expected ) );
 		assertEquals( expected.hashCode(), pixel.hashCode() );
+	}
+
+	@Test
+	public void testGetType()
+	{
+		ImgLabeling< String, IntType > imgLabeling = new ImgLabeling<>( ArrayImgs.ints( 10, 10 ) );
+		LabelingType< String > type = imgLabeling.getType().createVariable();
+		type.clear();
+		type.add( "A" );
+		assertEquals( Collections.singleton( "A" ), type );
 	}
 }


### PR DESCRIPTION
The bug was discovered by compiling and testing Labkit against imglib2-7.1. Trying to use the brush in Labkit would trigger this NullPointerException.

I'm unsure about the rules for implementing the new getType() so please have a closer look at my suggested change and whether is correct.

I also noticed that **(A)** `imgLabeling.getType().createVariable()` would behave differently than **(B)** `imgLabeling.randomAccess().get().createVariable()`. (A) creates a LabelingType with a independent LabelMapping while (B) creates a LabelingType with the same LabelMapping as the imgLabeling. In Labkit I'm now using implementation (B) because a need the same LabelMapping in order for LabelingType.set(...) to work properly.
